### PR TITLE
Enable the getter of observational models to use the state instead of dataset

### DIFF
--- a/leaspy/models/abstract_model.py
+++ b/leaspy/models/abstract_model.py
@@ -92,16 +92,16 @@ class AbstractModel(BaseModel):
     """
 
     def __init__(
-        self,
-        name: str,
-        *,
-        # TODO? if we'd allow to pass a state there should be a all bunch of checks I guess? only "equality" of DAG is OK?
-        # (WIP: cf. comment regarding inclusion of state here)
-        # state: Optional[State] = None,
-        # TODO? Factory of `ObservationModel` instead? (typically one would need the dimension to instantiate the `noise_std` variable of the right shape...)
-        obs_models: Union[ObservationModel, Iterable[ObservationModel]],
-        fit_metrics: Optional[Dict[str, float]] = None,
-        **kwargs
+            self,
+            name: str,
+            *,
+            # TODO? if we'd allow to pass a state there should be a all bunch of checks I guess? only "equality" of DAG is OK?
+            # (WIP: cf. comment regarding inclusion of state here)
+            # state: Optional[State] = None,
+            # TODO? Factory of `ObservationModel` instead? (typically one would need the dimension to instantiate the `noise_std` variable of the right shape...)
+            obs_models: Union[ObservationModel, Iterable[ObservationModel]],
+            fit_metrics: Optional[Dict[str, float]] = None,
+            **kwargs
     ):
         super().__init__(name, **kwargs)
 
@@ -134,7 +134,7 @@ class AbstractModel(BaseModel):
     #     self.check_noise_model_compatibility(noise_model)
     #     self._noise_model = noise_model
     #
-    #def check_noise_model_compatibility(self, model: BaseNoiseModel) -> None:
+    # def check_noise_model_compatibility(self, model: BaseNoiseModel) -> None:
     #    """
     #    Raise a LeaspyModelInputError is the provided noise model isn't compatible with the model instance.
     #    This needs to be implemented in subclasses.
@@ -267,9 +267,10 @@ class AbstractModel(BaseModel):
         extra_vars = set(parameters).difference(self.dag)
         if len(extra_vars):
             raise LeaspyModelInputError(f"Unknown model variables: {extra_vars}")
+
         # TODO: check no DataVariable provided???
-        #extra_params = set(parameters).difference(cur_params)
-        #if len(extra_params):
+        # extra_params = set(parameters).difference(cur_params)
+        # if len(extra_params):
         #    # e.g. mixing matrix, which is a derived variable - checking their values only
         #    warnings.warn(f"Ignoring some provided values that are not model parameters: {extra_params}")
 
@@ -386,20 +387,20 @@ class AbstractModel(BaseModel):
 
         # Model supports and needs sources?
         has_sources = (
-            hasattr(self, 'source_dimension')
-            and isinstance(self.source_dimension, int)
-            and self.source_dimension > 0
+                hasattr(self, 'source_dimension')
+                and isinstance(self.source_dimension, int)
+                and self.source_dimension > 0
         )
 
         # Check parameters names
-        expected_parameters = set(['xi', 'tau'] + int(has_sources)*['sources'])
+        expected_parameters = set(['xi', 'tau'] + int(has_sources) * ['sources'])
         given_parameters = set(ips.keys())
         symmetric_diff = expected_parameters.symmetric_difference(given_parameters)
         if len(symmetric_diff) > 0:
             raise LeaspyIndividualParamsInputError(
-                    f'Individual parameters dict provided {given_parameters} '
-                    f'is not compatible for {self.name} model. '
-                    f'The expected individual parameters are {expected_parameters}.')
+                f'Individual parameters dict provided {given_parameters} '
+                f'is not compatible for {self.name} model. '
+                f'The expected individual parameters are {expected_parameters}.')
 
         # Check number of individuals present (with low constraints on shapes)
         ips_is_array_like = {k: is_array_like(v) for k, v in ips.items()}
@@ -485,11 +486,11 @@ class AbstractModel(BaseModel):
         return x
 
     def _get_tensorized_inputs(
-        self,
-        timepoints: torch.Tensor,
-        individual_parameters: DictParamsTorch,
-        *,
-        skip_ips_checks: bool = False,
+            self,
+            timepoints: torch.Tensor,
+            individual_parameters: DictParamsTorch,
+            *,
+            skip_ips_checks: bool = False,
     ) -> Tuple[torch.Tensor, DictParamsTorch]:
         if not skip_ips_checks:
             # Perform checks on ips and gets tensorized version if needed
@@ -521,11 +522,11 @@ class AbstractModel(BaseModel):
 
     # TODO: unit tests? (functional tests covered by api.estimate)
     def compute_individual_trajectory(
-        self,
-        timepoints,
-        individual_parameters: DictParams,
-        *,
-        skip_ips_checks: bool = False,
+            self,
+            timepoints,
+            individual_parameters: DictParams,
+            *,
+            skip_ips_checks: bool = False,
     ) -> TensorOrWeightedTensor[float]:
         """
         Compute scores values at the given time-point(s) given a subject's individual parameters.
@@ -571,11 +572,11 @@ class AbstractModel(BaseModel):
         return local_state["model"]
 
     def compute_prior_trajectory(
-        self,
-        timepoints: torch.Tensor,
-        prior_type: LatentVariableInitType,
-        *,
-        n_individuals: Optional[int] = None,
+            self,
+            timepoints: torch.Tensor,
+            prior_type: LatentVariableInitType,
+            *,
+            n_individuals: Optional[int] = None,
     ) -> TensorOrWeightedTensor[float]:
         """
         Compute trajectory of the model for prior mode or mean of individual parameters.
@@ -601,8 +602,8 @@ class AbstractModel(BaseModel):
                 raise exc_n_ind_iff_prior_samples
             n_individuals = 1
         elif (
-            prior_type is not LatentVariableInitType.PRIOR_SAMPLES
-            or not (isinstance(n_individuals, int) and n_individuals >= 1)
+                prior_type is not LatentVariableInitType.PRIOR_SAMPLES
+                or not (isinstance(n_individuals, int) and n_individuals >= 1)
         ):
             raise exc_n_ind_iff_prior_samples
         local_state = self.state.clone(disable_auto_fork=True)
@@ -622,10 +623,10 @@ class AbstractModel(BaseModel):
 
     # TODO: unit tests? (functional tests covered by api.estimate)
     def compute_individual_ages_from_biomarker_values(
-        self,
-        value: Union[float, List[float]],
-        individual_parameters: DictParams,
-        feature: Optional[FeatureType] = None,
+            self,
+            value: Union[float, List[float]],
+            individual_parameters: DictParams,
+            feature: Optional[FeatureType] = None,
     ) -> torch.Tensor:
         """
         For one individual, compute age(s) at which the given features values
@@ -668,12 +669,12 @@ class AbstractModel(BaseModel):
             value, individual_parameters, feature
         )
 
-    #@abstractmethod
+    # @abstractmethod
     def compute_individual_ages_from_biomarker_values_tensorized(
-        self,
-        value: torch.Tensor,
-        individual_parameters: DictParamsTorch,
-        feature: Optional[FeatureType],
+            self,
+            value: torch.Tensor,
+            individual_parameters: DictParamsTorch,
+            feature: Optional[FeatureType],
     ) -> torch.Tensor:
         """
         For one individual, compute age(s) at which the given features values are
@@ -704,8 +705,8 @@ class AbstractModel(BaseModel):
         raise NotImplementedError("TODO in child classes")
 
     def compute_jacobian_tensorized(
-        self,
-        state: State,
+            self,
+            state: State,
     ) -> DictParamsTorch:
         """
         Compute the jacobian of the model w.r.t. each individual parameter, given the input state.
@@ -758,11 +759,11 @@ class AbstractModel(BaseModel):
 
     @classmethod
     def update_parameters(
-        cls,
-        state: State,
-        sufficient_statistics: SuffStatsRO,
-        *,
-        burn_in: bool,
+            cls,
+            state: State,
+            sufficient_statistics: SuffStatsRO,
+            *,
+            burn_in: bool,
     ) -> None:
         """
         Update model parameters of the provided state.
@@ -794,7 +795,7 @@ class AbstractModel(BaseModel):
         if isinstance(v, float) or getattr(v, 'ndim', -1) == 0:
             # for 0D tensors / arrays the default behavior is to print all digits...
             # change this!
-            return f'{v:.{1+torch_print_opts.precision}g}'
+            return f'{v:.{1 + torch_print_opts.precision}g}'
         if isinstance(v, (list, frozenset, set, tuple)):
             try:
                 return cls._serialize_tensor(torch.tensor(list(v)), indent=indent, sub_indent=sub_indent)
@@ -804,7 +805,7 @@ class AbstractModel(BaseModel):
             if not len(v):
                 return ""
             subs = [
-                f"{p} : " + cls._serialize_tensor(vp, indent="  ", sub_indent=" "*len(f"{p} : ["))
+                f"{p} : " + cls._serialize_tensor(vp, indent="  ", sub_indent=" " * len(f"{p} : ["))
                 for p, vp in v.items()
             ]
             lines = [indent + _ for _ in "\n".join(subs).split("\n")]
@@ -833,10 +834,10 @@ class AbstractModel(BaseModel):
 
     @staticmethod
     def time_reparametrization(
-        *,
-        t: torch.Tensor,  # TODO: TensorOrWeightedTensor?
-        alpha: torch.Tensor,
-        tau: torch.Tensor,
+            *,
+            t: torch.Tensor,  # TODO: TensorOrWeightedTensor?
+            alpha: torch.Tensor,
+            tau: torch.Tensor,
     ) -> torch.Tensor:
         """
         Tensorized time reparametrization formula.
@@ -859,12 +860,12 @@ class AbstractModel(BaseModel):
         """
         return alpha * (t - tau)
 
-    #@abstractmethod
-    #def model(self, **kws) -> torch.Tensor:
+    # @abstractmethod
+    # def model(self, **kws) -> torch.Tensor:
     #    pass
     #
-    #@abstractmethod
-    #def model_jacobian(self, **kws) -> torch.Tensor:
+    # @abstractmethod
+    # def model_jacobian(self, **kws) -> torch.Tensor:
     #    pass
 
     def get_variables_specs(self) -> NamedVariables:
@@ -881,8 +882,8 @@ class AbstractModel(BaseModel):
             "t": DataVariable(),
             "y": DataVariable(),
             "rt": LinkedVariable(self.time_reparametrization),
-            #"model": LinkedVariable(self.model),  # function arguments may depends on hyperparameters so postpone (e.g. presence of sources or not)
-            #"model_jacobian_{ip}": LinkedVariable(self.model_jacobian), for ip in IndividualLatentVariables....
+            # "model": LinkedVariable(self.model),  # function arguments may depends on hyperparameters so postpone (e.g. presence of sources or not)
+            # "model_jacobian_{ip}": LinkedVariable(self.model_jacobian), for ip in IndividualLatentVariables....
         })
 
         single_obs_model = len(self.obs_models) == 1
@@ -894,7 +895,7 @@ class AbstractModel(BaseModel):
                 "WIP: Only 1 noise model supported for now, but to be extended."
             )
             d.update(
-                #nll_attach_full=LinkedVariable(Sum(...)),
+                # nll_attach_full=LinkedVariable(Sum(...)),
                 nll_attach_ind=LinkedVariable(Sum(...)),
                 nll_attach=LinkedVariable(Sum(...)),
                 # TODO Same for nll_attach_ind jacobian, w.r.t each observation var???
@@ -940,7 +941,6 @@ class AbstractModel(BaseModel):
 
         # WIP: design of this may be better somehow?
         with self._state.auto_fork(None):
-
             # Set model parameters
             self.initialize_model_parameters(dataset, method=method)
 

--- a/leaspy/models/obs_models/_base.py
+++ b/leaspy/models/obs_models/_base.py
@@ -63,7 +63,6 @@ class ObservationModel:
         else:
             nll_attach_var = f"nll_attach"
         return {
-            self.name: DataVariable(),
             # Dependent vars
             **(self.extra_vars or {}),
             # Attachment variables

--- a/leaspy/models/obs_models/_base.py
+++ b/leaspy/models/obs_models/_base.py
@@ -22,7 +22,7 @@ from leaspy.variables.specs import (
     LinkedVariable,
     LVL_IND,
 )
-from leaspy.io.data.dataset import Dataset
+from leaspy.variables.state import State
 
 
 @dataclass(frozen=True)
@@ -37,8 +37,8 @@ class ObservationModel:
     ----------
     name : :obj:`str`
         The name of observed variable (to name the data variable & attachment term related to this observation).
-    getter : function :class:`.Dataset` -> :class:`.WeightedTensor`
-        The way to retrieve the observed values from the :class:`.Dataset` (as a :class:`.WeightedTensor`):
+    getter : function :class:`.State` -> :class:`.WeightedTensor`
+        The way to retrieve the observed values from the :class:`.State` (as a :class:`.WeightedTensor`):
         e.g. all values, subset of values - only x, y, z features, one-hot encoded features, ...
     dist : :class:`.SymbolicDistribution`
         The symbolic distribution, parametrized by model variables, for observed values (so to compute attachment).
@@ -48,7 +48,7 @@ class ObservationModel:
     """
 
     name: VarName
-    getter: Callable[[Dataset], WeightedTensor]
+    getter: Callable[[State], WeightedTensor]
     dist: SymbolicDistribution
     extra_vars: Optional[TMapping[VarName, VariableInterface]] = None
 

--- a/leaspy/models/obs_models/_base.py
+++ b/leaspy/models/obs_models/_base.py
@@ -11,7 +11,6 @@ from typing import (
 )
 from dataclasses import dataclass
 
-
 from leaspy.variables.distributions import SymbolicDistribution
 from leaspy.utils.weighted_tensor import WeightedTensor, sum_dim
 from leaspy.utils.functional import SumDim
@@ -53,8 +52,8 @@ class ObservationModel:
     extra_vars: Optional[TMapping[VarName, VariableInterface]] = None
 
     def get_variables_specs(
-        self,
-        named_attach_vars: bool = True,
+            self,
+            named_attach_vars: bool = True,
     ) -> Dict[VarName, VariableInterface]:
         """Automatic specifications of variables for this observation model."""
         # TODO change? a bit dirty? possibility of having aliases for variables?

--- a/leaspy/models/obs_models/_bernoulli.py
+++ b/leaspy/models/obs_models/_bernoulli.py
@@ -23,9 +23,9 @@ class BernoulliObservationModel(ObservationModel):
 
     @staticmethod
     def y_getter(state: State) -> WeightedTensor:
-        if dataset.values is None or dataset.mask is None:
+        if state['y'] is None:
             raise ValueError(
                 "Provided dataset is not valid. "
                 "Both values and mask should be not None."
             )
-        return WeightedTensor(state['y'], weight=dataset.mask.to(torch.bool))
+        return state['y']

--- a/leaspy/models/obs_models/_bernoulli.py
+++ b/leaspy/models/obs_models/_bernoulli.py
@@ -3,7 +3,7 @@ import torch
 from leaspy.variables.distributions import Bernoulli
 from leaspy.variables.specs import VariableInterface
 from leaspy.utils.weighted_tensor import WeightedTensor
-from leaspy.io.data.dataset import Dataset
+from leaspy.variables.state import State
 
 from ._base import ObservationModel
 
@@ -22,10 +22,10 @@ class BernoulliObservationModel(ObservationModel):
         )
 
     @staticmethod
-    def y_getter(dataset: Dataset) -> WeightedTensor:
+    def y_getter(state: State) -> WeightedTensor:
         if dataset.values is None or dataset.mask is None:
             raise ValueError(
                 "Provided dataset is not valid. "
                 "Both values and mask should be not None."
             )
-        return WeightedTensor(dataset.values, weight=dataset.mask.to(torch.bool))
+        return WeightedTensor(state['y'], weight=dataset.mask.to(torch.bool))

--- a/leaspy/models/obs_models/_bernoulli.py
+++ b/leaspy/models/obs_models/_bernoulli.py
@@ -11,8 +11,8 @@ from ._base import ObservationModel
 class BernoulliObservationModel(ObservationModel):
 
     def __init__(
-        self,
-        **extra_vars: VariableInterface,
+            self,
+            **extra_vars: VariableInterface,
     ):
         super().__init__(
             name="y",

--- a/leaspy/models/obs_models/_bernoulli.py
+++ b/leaspy/models/obs_models/_bernoulli.py
@@ -23,9 +23,4 @@ class BernoulliObservationModel(ObservationModel):
 
     @staticmethod
     def y_getter(state: State) -> WeightedTensor:
-        if state['y'] is None:
-            raise ValueError(
-                "Provided dataset is not valid. "
-                "Both values and mask should be not None."
-            )
         return state['y']

--- a/leaspy/models/obs_models/_gaussian.py
+++ b/leaspy/models/obs_models/_gaussian.py
@@ -66,7 +66,6 @@ class FullGaussianObservationModel(GaussianObservationModel):
 
     @staticmethod
     def y_getter(state: State) -> WeightedTensor:
-        assert  state['y'] is not None
         return state['y']
 
     @classmethod

--- a/leaspy/models/obs_models/_gaussian.py
+++ b/leaspy/models/obs_models/_gaussian.py
@@ -66,9 +66,8 @@ class FullGaussianObservationModel(GaussianObservationModel):
 
     @staticmethod
     def y_getter(state: State) -> WeightedTensor:
-        assert dataset.values is not None
-        assert dataset.mask is not None
-        return WeightedTensor(state['y'], weight=dataset.mask.to(torch.bool))
+        assert  state['y'] is not None
+        return state['y']
 
     @classmethod
     def noise_std_suff_stats(cls) -> Dict[VarName, LinkedVariable]:

--- a/leaspy/models/obs_models/_gaussian.py
+++ b/leaspy/models/obs_models/_gaussian.py
@@ -18,7 +18,6 @@ from leaspy.variables.specs import (
     Collect,
     LVL_FT,
 )
-from leaspy.io.data.dataset import Dataset
 from leaspy.variables.state import State
 
 from ._base import ObservationModel
@@ -30,7 +29,7 @@ class GaussianObservationModel(ObservationModel):
     def __init__(
         self,
         name: VarName,
-        getter: Callable[[Dataset], WeightedTensor],
+        getter: Callable[[State], WeightedTensor],
         loc: VarName,
         scale: VarName,
         **extra_vars: VariableInterface,
@@ -66,10 +65,10 @@ class FullGaussianObservationModel(GaussianObservationModel):
         )
 
     @staticmethod
-    def y_getter(dataset: Dataset) -> WeightedTensor:
+    def y_getter(state: State) -> WeightedTensor:
         assert dataset.values is not None
         assert dataset.mask is not None
-        return WeightedTensor(dataset.values, weight=dataset.mask.to(torch.bool))
+        return WeightedTensor(state['y'], weight=dataset.mask.to(torch.bool))
 
     @classmethod
     def noise_std_suff_stats(cls) -> Dict[VarName, LinkedVariable]:

--- a/leaspy/models/obs_models/_gaussian.py
+++ b/leaspy/models/obs_models/_gaussian.py
@@ -27,12 +27,12 @@ class GaussianObservationModel(ObservationModel):
     """Specialized `ObservationModel` for noisy observations with Gaussian residuals assumption."""
 
     def __init__(
-        self,
-        name: VarName,
-        getter: Callable[[State], WeightedTensor],
-        loc: VarName,
-        scale: VarName,
-        **extra_vars: VariableInterface,
+            self,
+            name: VarName,
+            getter: Callable[[State], WeightedTensor],
+            loc: VarName,
+            scale: VarName,
+            **extra_vars: VariableInterface,
     ):
         super().__init__(name, getter, Normal(loc, scale), extra_vars=extra_vars)
 
@@ -78,11 +78,11 @@ class FullGaussianObservationModel(GaussianObservationModel):
 
     @classmethod
     def scalar_noise_std_update(
-        cls,
-        *,
-        state: State,
-        y_x_model: WeightedTensor[float],
-        model_x_model: WeightedTensor[float],
+            cls,
+            *,
+            state: State,
+            y_x_model: WeightedTensor[float],
+            model_x_model: WeightedTensor[float],
     ) -> torch.Tensor:
         """Update rule for scalar `noise_std` (when directly a model parameter), from state & sufficient statistics."""
         y_l2, n_obs = state["y_L2_and_n_obs"]
@@ -99,11 +99,11 @@ class FullGaussianObservationModel(GaussianObservationModel):
 
     @classmethod
     def diagonal_noise_std_update(
-        cls,
-        *,
-        state: State,
-        y_x_model: WeightedTensor[float],
-        model_x_model: WeightedTensor[float],
+            cls,
+            *,
+            state: State,
+            y_x_model: WeightedTensor[float],
+            model_x_model: WeightedTensor[float],
     ) -> torch.Tensor:
         """
         Update rule for feature-wise `noise_std` (when directly a model parameter),
@@ -159,10 +159,10 @@ class FullGaussianObservationModel(GaussianObservationModel):
 
     @classmethod
     def compute_rmse(
-        cls,
-        *,
-        y: WeightedTensor[float],
-        model: WeightedTensor[float],
+            cls,
+            *,
+            y: WeightedTensor[float],
+            model: WeightedTensor[float],
     ) -> torch.Tensor:
         """Compute root mean square error."""
         l2: WeightedTensor[float] = (model - y) ** 2
@@ -171,10 +171,10 @@ class FullGaussianObservationModel(GaussianObservationModel):
 
     @classmethod
     def compute_rmse_per_ft(
-        cls,
-        *,
-        y: WeightedTensor[float],
-        model: WeightedTensor[float],
+            cls,
+            *,
+            y: WeightedTensor[float],
+            model: WeightedTensor[float],
     ) -> torch.Tensor:
         """Compute root mean square error, per feature."""
         l2: WeightedTensor[float] = (model - y) ** 2

--- a/leaspy/models/obs_models/_ordinal.py
+++ b/leaspy/models/obs_models/_ordinal.py
@@ -13,8 +13,8 @@ class OrdinalObservationModel(ObservationModel):
     ordinal_infos = {}
 
     def __init__(
-        self,
-        **extra_vars: VariableInterface,
+            self,
+            **extra_vars: VariableInterface,
     ):
         super().__init__(
             name="y",
@@ -25,5 +25,5 @@ class OrdinalObservationModel(ObservationModel):
 
     def y_getter(self, state: State) -> WeightedTensor:
         # Why isn't it computed once for all ?
-        #pdf = dataset.get_one_hot_encoding(sf=False, ordinal_infos=self.ordinal_infos)
+        # pdf = dataset.get_one_hot_encoding(sf=False, ordinal_infos=self.ordinal_infos)
         return state['y']

--- a/leaspy/models/obs_models/_ordinal.py
+++ b/leaspy/models/obs_models/_ordinal.py
@@ -24,11 +24,11 @@ class OrdinalObservationModel(ObservationModel):
         )
 
     def y_getter(self, state: State) -> WeightedTensor:
-        if dataset.values is None or dataset.mask is None:
+        if state['y'] is None :
             raise ValueError(
                 "Provided dataset is not valid. "
                 "Both values and mask should be not None."
             )
         # Why isn't it computed once for all ?
         #pdf = dataset.get_one_hot_encoding(sf=False, ordinal_infos=self.ordinal_infos)
-        return WeightedTensor(state['y'], weight=dataset.mask.to(torch.bool))
+        return state['y']

--- a/leaspy/models/obs_models/_ordinal.py
+++ b/leaspy/models/obs_models/_ordinal.py
@@ -4,6 +4,7 @@ from leaspy.io.data.dataset import Dataset
 from leaspy.utils.weighted_tensor import WeightedTensor
 from leaspy.variables.specs import VariableInterface
 from leaspy.variables.distributions import Ordinal
+from leaspy.variables.state import State
 
 from ._base import ObservationModel
 
@@ -22,11 +23,12 @@ class OrdinalObservationModel(ObservationModel):
             extra_vars=extra_vars,
         )
 
-    def y_getter(self, dataset: Dataset) -> WeightedTensor:
+    def y_getter(self, state: State) -> WeightedTensor:
         if dataset.values is None or dataset.mask is None:
             raise ValueError(
                 "Provided dataset is not valid. "
                 "Both values and mask should be not None."
             )
-        pdf = dataset.get_one_hot_encoding(sf=False, ordinal_infos=self.ordinal_infos)
-        return WeightedTensor(pdf, weight=dataset.mask.to(torch.bool))
+        # Why isn't it computed once for all ?
+        #pdf = dataset.get_one_hot_encoding(sf=False, ordinal_infos=self.ordinal_infos)
+        return WeightedTensor(state['y'], weight=dataset.mask.to(torch.bool))

--- a/leaspy/models/obs_models/_ordinal.py
+++ b/leaspy/models/obs_models/_ordinal.py
@@ -24,11 +24,6 @@ class OrdinalObservationModel(ObservationModel):
         )
 
     def y_getter(self, state: State) -> WeightedTensor:
-        if state['y'] is None :
-            raise ValueError(
-                "Provided dataset is not valid. "
-                "Both values and mask should be not None."
-            )
         # Why isn't it computed once for all ?
         #pdf = dataset.get_one_hot_encoding(sf=False, ordinal_infos=self.ordinal_infos)
         return state['y']


### PR DESCRIPTION
In GitLab by @JulietteOrtholand on Aug 22, 2023, 09:42

The observational model could only access variable that were stored in dataset. But for the joint model, I would need it to use a linked variable which is just a reparametrisation of a dataset variable, but it seems to me that it was cleaner to use a linked variable rather than make the computations inside of the observational model. Thus I needed the observational model to get access to the state instead of just the dataset. This MR is linked to the issue #87 and more broadly to #84 .