### PR TITLE
Event tensors

### DIFF
--- a/leaspy/models/obs_models/_weibull.py
+++ b/leaspy/models/obs_models/_weibull.py
@@ -1,9 +1,5 @@
-import torch
-
 from leaspy.variables.distributions import WeibullRightCensored
-from leaspy.variables.specs import VariableInterface
-from leaspy.utils.weighted_tensor import WeightedTensor
-from leaspy.utils.weighted_tensor import WeightedTensor, sum_dim
+from leaspy.utils.weighted_tensor import EventTensor
 from leaspy.io.data.dataset import Dataset
 
 from ._base import ObservationModel
@@ -11,33 +7,20 @@ from leaspy.variables.specs import (
     VarName,
     VariableInterface,
     LinkedVariable,
-    DataVariable,
-    ModelParameter,
-    Collect,
-    LVL_FT,
-    LVL_IND,
 )
-from typing import (
-    Dict,
-    Callable,
-    Optional,
-    Any,
-    Mapping as TMapping,
-)
-from leaspy.utils.functional import SumDim
-
+from typing import Dict
 
 
 class WeibullRightCensoredObservationModel(ObservationModel):
     string_for_json = "weibull-right-censored"
 
     def __init__(
-            self,
-            nu: VarName,
-            rho: VarName,
-            xi: VarName,
-            tau: VarName,
-            **extra_vars: VariableInterface,
+        self,
+        nu: VarName,
+        rho: VarName,
+        xi: VarName,
+        tau: VarName,
+        **extra_vars: VariableInterface,
     ):
         super().__init__(
             name="event",
@@ -47,22 +30,20 @@ class WeibullRightCensoredObservationModel(ObservationModel):
         )
 
     @staticmethod
-    def getter(dataset: Dataset) -> WeightedTensor:
+    def getter(dataset: Dataset) -> EventTensor:
         if dataset.event_time is None or dataset.event_bool is None:
             raise ValueError(
                 "Provided dataset is not valid. "
                 "Both values and mask should be not None."
             )
-        return WeightedTensor(dataset.event_time, dataset.event_bool)
+        return EventTensor(dataset.event_time, dataset.event_bool)
 
     def get_variables_specs(
         self,
         named_attach_vars: bool = True,
     ) -> Dict[VarName, VariableInterface]:
         """Automatic specifications of variables for this observation model."""
-
         specs = super().get_variables_specs(named_attach_vars)
-
         nll_attach_var = self.get_nll_attach_var_name(
             named_attach_vars
         )

--- a/leaspy/models/obs_models/_weibull.py
+++ b/leaspy/models/obs_models/_weibull.py
@@ -70,13 +70,15 @@ class WeibullRightCensoredObservationModel(ObservationModel):
             self.dist.get_func_nll(self.name)
         )
         specs[f"survival_{self.name}"] = LinkedVariable(
-            self.dist._get_func("compute_log_survival", self.name)
+            self.dist.get_func("compute_log_survival", self.name)
         )
         return specs
 
     @classmethod
-    def default_init(self, **kwargs):
-        return self(nu = kwargs.pop("nu", "nu"),
-                    rho = kwargs.pop("rho", "rho"),
-                    xi = kwargs.pop("xi", "xi"),
-                    tau = kwargs.pop("tau", "tau"))
+    def default_init(cls, **kwargs):
+        return cls(
+            nu=kwargs.pop("nu", "nu"),
+            rho=kwargs.pop("rho", "rho"),
+            xi=kwargs.pop("xi", "xi"),
+            tau=kwargs.pop("tau", "tau"),
+        )

--- a/leaspy/utils/weighted_tensor/__init__.py
+++ b/leaspy/utils/weighted_tensor/__init__.py
@@ -8,10 +8,11 @@ from ._utils import (
     wsum_dim_return_weighted_sum_only,
     wsum_dim_return_sum_of_weights_only,
 )
-from ._weighted_tensor import WeightedTensor, TensorOrWeightedTensor
+from ._weighted_tensor import WeightedTensor, TensorOrWeightedTensor, EventTensor
 
 
 __all__ = [
+    "EventTensor",
     "expand_left",
     "expand_right",
     "factory_weighted_tensor_unary_operator",

--- a/leaspy/utils/weighted_tensor/_weighted_tensor.py
+++ b/leaspy/utils/weighted_tensor/_weighted_tensor.py
@@ -320,3 +320,8 @@ for cmp_name in ("lt", "le", "eq", "ne", "gt", "ge"):
         f"__{cmp_name}__",
         _factory_for_binary_operator(cmp_name, fill_value=None),
     )  # float('nan')
+
+
+class EventTensor(WeightedTensor):
+    """Special case where the WeightedTensor represents an event."""
+    pass

--- a/leaspy/variables/distributions.py
+++ b/leaspy/variables/distributions.py
@@ -642,9 +642,9 @@ class SymbolicDistribution:
                 f"while expecting {len(self.dist_family.parameters)}: {self.dist_family.parameters}"
             )
         for bypass_method in {"validate_parameters", "shape", "mode", "mean", "stddev"}:
-            object.__setattr__(self, bypass_method, self._get_func(bypass_method))
+            object.__setattr__(self, bypass_method, self.get_func(bypass_method))
 
-    def _get_func(self, func: str, *extra_args_names: str, **kws):
+    def get_func(self, func: str, *extra_args_names: str, **kws):
         """Get keyword-only function from the stateless distribution family."""
         return NamedInputFunction(
             getattr(self.dist_family, func),
@@ -653,7 +653,7 @@ class SymbolicDistribution:
         )
 
     def get_func_sample(
-            self, sample_shape: Tuple[int, ...] = ()
+        self, sample_shape: Tuple[int, ...] = ()
     ) -> NamedInputFunction[torch.Tensor]:
         """
         Factory of symbolic sampling function.
@@ -669,10 +669,10 @@ class SymbolicDistribution:
         NamedInputFunction :
             The sample function.
         """
-        return self._get_func("sample", sample_shape=sample_shape)
+        return self.get_func("sample", sample_shape=sample_shape)
 
     def get_func_nll(
-            self, value_name: str
+        self, value_name: str
     ) -> NamedInputFunction[WeightedTensor[float]]:
         """
         Factory of symbolic function: state -> negative log-likelihood of value.
@@ -686,10 +686,10 @@ class SymbolicDistribution:
         NamedInputFunction :
             The named input function to use to compute negative log likelihood.
         """
-        return self._get_func("nll", value_name)
+        return self.get_func("nll", value_name)
 
     def get_func_nll_jacobian(
-            self, value_name: str
+        self, value_name: str
     ) -> NamedInputFunction[WeightedTensor[float]]:
         """
         Factory of symbolic function: state -> jacobian w.r.t. value of negative log-likelihood.
@@ -703,10 +703,10 @@ class SymbolicDistribution:
         NamedInputFunction :
             The named input function to use to compute negative log likelihood jacobian.
         """
-        return self._get_func("nll_jacobian", value_name)
+        return self.get_func("nll_jacobian", value_name)
 
     def get_func_nll_and_jacobian(
-            self, value_name: str
+        self, value_name: str
     ) -> NamedInputFunction[Tuple[WeightedTensor[float], WeightedTensor[float]]]:
         """
         Factory of symbolic function: state -> (negative log-likelihood, its jacobian w.r.t. value).
@@ -720,12 +720,12 @@ class SymbolicDistribution:
         Tuple[NamedInputFunction, NamedInputFunction] :
             The named input functions to use to compute negative log likelihood and its jacobian.
         """
-        return self._get_func("nll_and_jacobian", value_name)
+        return self.get_func("nll_and_jacobian", value_name)
 
     @classmethod
     def bound_to(
-            cls,
-            dist_family: Type[StatelessDistributionFamily],
+        cls,
+        dist_family: Type[StatelessDistributionFamily],
     ) -> Callable[..., SymbolicDistribution]:
         """
         Return a factory to create `SymbolicDistribution` bound to the provided distribution family.


### PR DESCRIPTION
In GitLab by @NicolasGensollen on Mar 25, 2024, 10:50

### What does the code in the MR do ?

The goal of this MR is to find another way than !124 of fixing #102 

The issue with !124 is that it changes the return value type of method `_nll` from a `Tensor` to a `WeightedTensor` which is in contradiction with the base class and other subclasses.

Also, it changes the behavior of `_get_func_result_for_tensor_or_weighted_tensor` when the passed value is a `WeightedTensor` 

I think that the issue comes from the fact that we are using a `WeightedTensor` to model something that isn't really a weighted tensor in the same way as the other variables. In most cases, events should be handled in the same way as regular variables represented as weighted tensors, but in a few cases they should be handled differently because the weights have a slightly different meaning for events.

This MR proposes to introduce a new `EventTensor` class, which is a simple subclass of `WeightedTensor`. The main logic modifications are:

* The getter of `WeibullRightCensoredObservationModel` returns an `EventTensor` 
* All Weibull family objects expect an `EventTensor` for parameter `x` instead of a `WeightedTensor` 
* `_get_func_result_for_tensor_or_weighted_tensor` doesn't do anything with the weights when it receives an `EventTensor`

The MR also proposes to make the `_get_func()` method of the `SymbolicDistribution` class public since it seemed to simplify the code in the `WeibullRightCensoredObservationModel`

The rest of the modifications are basically PEP8 stuffs.