### PR TITLE
Change the source distribution

### DIFF
--- a/leaspy/models/abstract_multivariate_model.py
+++ b/leaspy/models/abstract_multivariate_model.py
@@ -19,7 +19,7 @@ from leaspy.variables.specs import (
     LinkedVariable,
     VariablesValuesRO,
 )
-from leaspy.variables.distributions import Normal
+from leaspy.variables.distributions import Laplace, Normal
 from leaspy.utils.functional import (
     Exp,
     MatMul,
@@ -145,7 +145,7 @@ class AbstractMultivariateModel(AbstractModel):  # OrdinalModelMixin,
                     sampling_kws={"scale": .5},   # cf. GibbsSampler (for retro-compat)
                 ),
                 sources=IndividualLatentVariable(
-                    Normal("sources_mean", "sources_std")
+                    Laplace("sources_mean", "sources_std")
                 ),
                 # DERIVED VARS
                 mixing_matrix=LinkedVariable(

--- a/leaspy/models/multivariate.py
+++ b/leaspy/models/multivariate.py
@@ -58,7 +58,9 @@ class MultivariateModel(AbstractMultivariateModel):
 
         default_variables_to_track = [
             "g",
+            "log_g_mean",
             "v0",
+            "log_v0_mean",
             "noise_std",
             "tau_mean",
             "tau_std",

--- a/leaspy/variables/distributions.py
+++ b/leaspy/variables/distributions.py
@@ -249,6 +249,12 @@ class BernoulliFamily(StatelessDistributionFamilyFromTorchDistribution):
     parameters: ClassVar = ("loc",)
     dist_factory: ClassVar = torch.distributions.Bernoulli
 
+class LaplaceFamily(StatelessDistributionFamilyFromTorchDistribution):
+    """Log Normal family (stateless)."""
+    parameters: ClassVar = ("loc","scale")
+    dist_factory: ClassVar = torch.distributions.laplace.Laplace
+
+
 
 class OrdinalFamily(StatelessDistributionFamilyFromTorchDistribution):
     """Ordinal family (stateless)."""
@@ -859,6 +865,7 @@ class SymbolicDistribution:
 
 
 Normal = SymbolicDistribution.bound_to(NormalFamily)
+Laplace = SymbolicDistribution.bound_to(LaplaceFamily)
 Bernoulli = SymbolicDistribution.bound_to(BernoulliFamily)
 Ordinal = SymbolicDistribution.bound_to(OrdinalFamily)
 WeibullRightCensored = SymbolicDistribution.bound_to(WeibullRightCensoredFamily)


### PR DESCRIPTION
In GitLab by @JulietteOrtholand on Oct 25, 2024, 16:54

### What does the code in the MR do ?
As explain in the slide below (the whole course is available at the end of the MR), the sources in an ICA cannot be gaussian... An for now in leaspy they are....
undefined

The idea was to replace the gaussian distribution by an other one. I first though about log-normal distribution, which is according to Stéphanie Allassonière paper (in ref at the end of the MR) "probably one of the most commonly used parametric models for ICA. One reason for this is that the logistic probability density function (p.d.f.) is easy to describe, smooth, with a shape similar to the Gaussian, but with heavier, exponential, tails.". But it is not eay to center it on 0 ... So I finally used a Laplace distribution.

### Where should the reviewer start ?
There are a few lines changed, and the code run. But still no scientific tests have been done. Thus, for now the main questions are:
- does the model still works: can it find back the model parameters (apart from the mixing matrix) and the random parameters,
- is now A identifiable?

## References
undefined

undefined