### PR TITLE
improve pdf file created by FOM

### DIFF
--- a/src/leaspy/algo/settings.py
+++ b/src/leaspy/algo/settings.py
@@ -44,7 +44,7 @@ class OutputsSettings:
                 Note that you can not plot convergence data without saving data (and not more frequently than these saves!)
             * plot_sourcewise : bool
                 Flag to plot source based multidimensional parameters such as mixing_matrix for each source.
-                Otherwise they will be plotted accroding to the other dimension such as feature.
+                Otherwise they will be plotted according to the other dimension such as feature.
                 Default=False
             * overwrite_logs_folder : bool
                 Flag to remove all previous logs if existing (default False)
@@ -530,7 +530,7 @@ class AlgorithmSettings:
                     * it should be a multiple of save_periodicity
                     * setting a too low value (frequent) we seriously slow down you fit
             * plot_sourcewise : bool, optional, default False
-                To plot source based parameters sourcewise
+                Set this to True to plot the source-based parameters sourcewise.
             * overwrite_logs_folder: bool, optional, default False
                 Set it to ``True`` to overwrite the content of the folder in ``path``.
             * nb_of_patients_to_plot: int, optional default 5

--- a/src/leaspy/algo/settings.py
+++ b/src/leaspy/algo/settings.py
@@ -42,6 +42,10 @@ class OutputsSettings:
                 Flag to plot convergence data every N iterations
                 If None, no plots will be saved.
                 Note that you can not plot convergence data without saving data (and not more frequently than these saves!)
+            * plot_sourcewise : bool
+                Flag to plot source based multidimensional parameters such as mixing_matrix for each source.
+                Otherwise they will be plotted accroding to the other dimension such as feature.
+                Default=False
             * overwrite_logs_folder : bool
                 Flag to remove all previous logs if existing (default False)
 
@@ -61,6 +65,7 @@ class OutputsSettings:
         self.print_periodicity = None
         self.plot_periodicity = None
         self.save_periodicity = 50
+        self.plot_sourcewise = False
         self.nb_of_patients_to_plot = 5
 
         self.root_path = None
@@ -71,6 +76,8 @@ class OutputsSettings:
         self._set_print_periodicity(settings)
         self._set_save_periodicity(settings)
         self._set_plot_periodicity(settings)
+        self._set_nb_of_patients_to_plot(settings)
+        self._set_plot_sourcewise(settings)
 
         # only create folders if the user want to save data or plots and provided a valid path!
         self._create_root_folder(settings)
@@ -96,6 +103,12 @@ class OutputsSettings:
 
         # Update the attribute of self in-place
         setattr(self, param, val)
+
+    def _set_plot_sourcewise(self, settings: dict):
+        setattr(self, "plot_sourcewise", settings["plot_sourcewise"])
+
+    def _set_nb_of_patients_to_plot(self, settings: dict):
+        self._set_param_as_int_or_ignore(settings, "nb_of_patients_to_plot")
 
     def _set_print_periodicity(self, settings: dict):
         self._set_param_as_int_or_ignore(settings, "print_periodicity")
@@ -516,6 +529,8 @@ class AlgorithmSettings:
                 Note that:
                     * it should be a multiple of save_periodicity
                     * setting a too low value (frequent) we seriously slow down you fit
+            * plot_sourcewise : bool, optional, default False
+                To plot source based parameters sourcewise
             * overwrite_logs_folder: bool, optional, default False
                 Set it to ``True`` to overwrite the content of the folder in ``path``.
             * nb_of_patients_to_plot: int, optional default 5
@@ -538,6 +553,7 @@ class AlgorithmSettings:
             "print_periodicity": None,
             "save_periodicity": 10,
             "plot_periodicity": 50,
+            "plot_sourcewise": False,
             "overwrite_logs_folder": False,
             "nb_of_patients_to_plot": 5,
         }
@@ -548,6 +564,7 @@ class AlgorithmSettings:
                 "plot_periodicity",
                 "save_periodicity",
                 "nb_of_patients_to_plot",
+                "plot_sourcewise",
             ):
                 if v is not None and not isinstance(v, int):
                     raise LeaspyAlgoInputError(

--- a/src/leaspy/io/logs/fit_output_manager.py
+++ b/src/leaspy/io/logs/fit_output_manager.py
@@ -291,9 +291,9 @@ class FitOutputManager:
         colors = colormaps["Dark2"](np.linspace(0, 1, number_of_patient_plot + 2))
 
         fig, ax = plt.subplots(1, 1)
-        ax.set_title(f"Feature trajectory for {number_of_patient_plot} patients")
+        ax.set_title(f"Feature" f" trajectory for {number_of_patient_plot} patients")
         ax.set_xlabel("Ages")
-        ax.set_ylabel("Normalized Feature Value")
+        ax.set_ylabel("Normalized " "Feature Value")
 
         for i in range(number_of_patient_plot):
             times_patient = data.get_times_patient(i).cpu().detach().numpy()

--- a/src/leaspy/io/logs/fit_output_manager.py
+++ b/src/leaspy/io/logs/fit_output_manager.py
@@ -291,9 +291,9 @@ class FitOutputManager:
         colors = colormaps["Dark2"](np.linspace(0, 1, number_of_patient_plot + 2))
 
         fig, ax = plt.subplots(1, 1)
-        ax.set_title(f"Feature" f" trajectory for {number_of_patient_plot} patients")
+        ax.set_title(f"Feature trajectory for {number_of_patient_plot} patients")
         ax.set_xlabel("Ages")
-        ax.set_ylabel("Normalized " "Feature Value")
+        ax.set_ylabel("Normalized Feature Value")
 
         for i in range(number_of_patient_plot):
             times_patient = data.get_times_patient(i).cpu().detach().numpy()

--- a/src/leaspy/io/logs/fit_output_manager.py
+++ b/src/leaspy/io/logs/fit_output_manager.py
@@ -329,8 +329,6 @@ class FitOutputManager:
 
     def _get_files_related_to_parameters(self, parameters: Iterable[str]) -> list[Path]:
         """
-        Helper function for `save_plot_convergence_model_parameters`
-
         Retrieve the list of file paths related to the given parameters.
 
         Parameters
@@ -353,8 +351,6 @@ class FitOutputManager:
         self, parameter_name: str
     ) -> tuple[Optional[str], Optional[int]]:
         """
-        Helper function for `save_plot_convergence_model_parameters`
-
         Extract the parameter name and its corresponding index (if applicable) from the given parameter name.
 
         Parameters
@@ -377,8 +373,6 @@ class FitOutputManager:
 
     def _set_title_for_parameter(self, ax, i, parameter_name: str, model, index):
         """
-        Helper function for `save_plot_convergence_model_parameters`
-
         Set the title for the plot based on the parameter name and the model's features or other information.
 
         Parameters
@@ -426,8 +420,6 @@ class FitOutputManager:
         model,
     ):
         """
-        Helper function for `save_plot_convergence_model_parameters`
-
         Set the legend for the plot based on the parameter name and the model's features, sources, or events.
 
         Parameters
@@ -472,8 +464,6 @@ class FitOutputManager:
 
     def _update_files_sourcewise(self, files_to_plot, params_with_sources, num_sources):
         """
-        Helper function for `save_plot_convergence_model_parameters`
-
         Update the list of files by creating sourcewise files based on the parameters with sources.
 
         This function processes parameters that have sources and generates new CSV files for each source.

--- a/tests/unit_tests/io_tests/logs/test_fit_output_manager.py
+++ b/tests/unit_tests/io_tests/logs/test_fit_output_manager.py
@@ -1,0 +1,38 @@
+import os
+
+import pytest
+from tests import LeaspyTestCase
+
+from leaspy.algo.settings import OutputsSettings
+from leaspy.api import Leaspy
+from leaspy.io.logs import FitOutputManager
+
+
+def test_fit_output_manager(tmp_path):
+    data = LeaspyTestCase.get_suited_test_data_for_model("logistic_diag_noise")
+    leaspy = Leaspy("logistic")
+    algo_settings = LeaspyTestCase.get_algo_settings(
+        name="mcmc_saem", n_iter=50, seed=0
+    )
+
+    output_settings = {
+        "path": tmp_path,
+        "print_periodicity": 10,
+        "save_periodicity": 10,
+        "plot_periodicity": 10,
+        "plot_sourcewise": False,
+        "overwrite_logs_folder": True,
+        "nb_of_patients_to_plot": 5,
+    }
+
+    logs = OutputsSettings(output_settings)
+    manager = FitOutputManager(logs)
+    algo_settings.logs = logs
+    leaspy.fit(data, settings=algo_settings)
+
+    assert (manager.path_plot_patients / "plot_patients_10.pdf").exists()
+    assert (manager.path_plot / "convergence_parameters.pdf").exists()
+
+    files_list = os.listdir(manager.path_save_model_parameters_convergence)
+    for parameter in leaspy.model.state._tracked_variables:
+        assert any(file.startswith(str(parameter)) for file in files_list)

--- a/tests/unit_tests/io_tests/settings/test_outputs_settings.py
+++ b/tests/unit_tests/io_tests/settings/test_outputs_settings.py
@@ -15,6 +15,7 @@ class OutputSettingsAndFitOutputManagerTest(LeaspyTestCase):
                 "save_periodicity": None,
                 "plot_periodicity": None,
                 "overwrite_logs_folder": False,
+                "plot_sourcewise": False,
             }
         )
 
@@ -65,6 +66,7 @@ class OutputSettingsAndFitOutputManagerTest(LeaspyTestCase):
                     "save_periodicity": 20,
                     "plot_periodicity": 40,
                     "overwrite_logs_folder": False,
+                    "plot_sourcewise": False,
                 }
             )
 
@@ -93,6 +95,7 @@ class OutputSettingsAndFitOutputManagerTest(LeaspyTestCase):
                     "save_periodicity": 23,
                     "plot_periodicity": 46,
                     "overwrite_logs_folder": False,
+                    "plot_sourcewise": False,
                 }
             )
 
@@ -122,6 +125,7 @@ class OutputSettingsAndFitOutputManagerTest(LeaspyTestCase):
                             "save_periodicity": None,
                             "plot_periodicity": None,
                             "overwrite_logs_folder": False,
+                            "plot_sourcewise": False,
                         }
                     )
                 self.assertIsNone(logs.print_periodicity)


### PR DESCRIPTION
This PR solves the issue #123 . 

To do this, I improved the `save_plot_convergence_model_parameters` function. Now, it creates a pdf with several pages (6 plots per page) and it plots some additional parameters such as mixing matrix for all models and zeta from joint model. Since these new parameters have multiple files, I have also added legends for them specifically. 


I add an example pdf which was created after fitting data with joint model.
[convergence_parameters.pdf](https://github.com/user-attachments/files/19029065/convergence_parameters.pdf)


