### PR TITLE
[SIMULATE] Simulate v2 - Change inputs and outputs format

### DIFF
--- a/src/leaspy/algo/data/default_simulation.json
+++ b/src/leaspy/algo/data/default_simulation.json
@@ -4,19 +4,9 @@
   "algorithm_initialization_method": null,
   "parameters": {
     "prefix":"Generated_subject_",
-    "number_of_subjects": 100,
-    "bandwidth_method": 0.2,
-    "noise": "inherit_struct",
-    "mean_number_of_visits": 6,
-    "std_number_of_visits": 3,
-    "min_number_of_visits": 1,
-    "max_number_of_visits": null,
-    "delay_btw_visits": 0.5,
     "cofactor": null,
     "cofactor_state": null,
-    "sources_method": "full_kde",
-    "reparametrized_age_bounds": null,
-    "features_bounds": false,
-    "features_bounds_nb_subjects_factor": 10
+    "features": null,
+    "visit_parameters": null
   }
 }

--- a/src/leaspy/algo/simulate/simulate.py
+++ b/src/leaspy/algo/simulate/simulate.py
@@ -23,6 +23,7 @@ class SimulationAlgorithm(AbstractAlgo):
 
     name: str = "simulation"
     family: AlgorithmType = AlgorithmType.SIMULATE
+<<<<<<< Updated upstream
 
 
     _PARAM_REQUIREMENTS = {
@@ -140,6 +141,15 @@ class SimulationAlgorithm(AbstractAlgo):
 
 
 
+=======
+
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.visit_type = settings.parameters["visit_type"] 
+        self.features = settings.parameters["features"]      
+        self.load_parameters(settings.parameters["load_parameters"])  
+
+>>>>>>> Stashed changes
     ## --- SET PARAMETERS ---
     def load_parameters(self, dict_param):
         self.set_param_repeated_measure(dict_param["repeated_measure"])
@@ -220,8 +230,12 @@ class SimulationAlgorithm(AbstractAlgo):
         #                     individual_parameters = df_ip_rm,
         #                     noise_std = noise_std_used,
         # )
+<<<<<<< Updated upstream
         return df_sim, None
 
+=======
+        return df_sim
+>>>>>>> Stashed changes
 
     ## ---- IP ---
     def get_ip_rm(self):
@@ -318,7 +332,10 @@ class SimulationAlgorithm(AbstractAlgo):
                 self.param_study["tf_std"],
                 self.param_study["pat_nb"],
             )
+<<<<<<< Updated upstream
 
+=======
+>>>>>>> Stashed changes
             ## Generate visit ages for each patients
             dict_timepoints = {}
 
@@ -412,5 +429,9 @@ class SimulationAlgorithm(AbstractAlgo):
         df_sim.set_index(["ID", "TIME"], inplace=True)
         df_sim = df_sim[~df_sim.index.duplicated()]
 
+<<<<<<< Updated upstream
         return df_sim
 
+=======
+        return df_sim
+>>>>>>> Stashed changes

--- a/src/leaspy/algo/simulate/simulate.py
+++ b/src/leaspy/algo/simulate/simulate.py
@@ -1,6 +1,7 @@
 import json
 from abc import ABC
 
+from enum import Enum
 import numpy as np
 import pandas as pd
 from scipy.stats import beta
@@ -10,17 +11,134 @@ from leaspy.io.outputs import IndividualParameters
 from leaspy.algo.base import AbstractAlgo, AlgorithmType
 from leaspy.io.outputs.result import Result
 from leaspy.io.data.data import Data
+from leaspy.exceptions import LeaspyAlgoInputError
+
+
+class VisitType(Enum):
+    DATAFRAME = "dataframe"   # Dataframe of visits
+    REGULAR = "regular"       # Regular spaced visits
+    RANDOM = "random"         # Random spaced visits
 
 class SimulationAlgorithm(AbstractAlgo):
 
     name: str = "simulation"
     family: AlgorithmType = AlgorithmType.SIMULATE
 
+
+    _PARAM_REQUIREMENTS = {
+        "dataframe": [
+            ("df_visits", pd.DataFrame),
+        ],
+        "regular": [
+            ("pat_nb", int),
+            ("regular_visit", (int, float)),
+            ("fv_mean", (int, float)),
+            ("fv_std", (int, float)),
+            ("tf_mean", (int, float)),
+            ("tf_std", (int, float)),
+        ],
+        "random": [
+            ("pat_nb", int),
+            ("fv_mean", (int, float)),
+            ("fv_std", (int, float)),
+            ("tf_mean", (int, float)),
+            ("tf_std", (int, float)),
+            ("distv_mean", (int, float)),
+            ("distv_std", (int, float)),
+        ]
+    }
+
     def __init__(self, settings):
         super().__init__(settings)
-        self.visit_type = settings.parameters["visit_type"] 
-        self.features = settings.parameters["features"]      
-        self.load_parameters(settings.parameters["load_parameters"])  
+        self.visit_type = settings.parameters["visit_type"]
+        self.features = settings.parameters["features"]
+        self.load_parameters(settings.parameters["load_parameters"])
+        self._validate_algo_parameters() 
+
+    ## --- CHECKS ---
+    def _check_visit_type(self):
+        if not isinstance(self.visit_type, str):
+            raise LeaspyAlgoInputError(
+                f"Visit type need to be a string and not : {type(self.visit_type).__name__}"
+            )
+        try:
+            VisitType(self.visit_type)
+        except ValueError as e:
+            allowed_types = [vt.value for vt in VisitType]
+            raise LeaspyAlgoInputError(
+                f"Invalid visit type : '{self.visit_type}'. "
+                f"Authorized typz : {', '.join(allowed_types)}"
+            ) from e
+
+
+    def _check_features(self):
+        if not isinstance(self.features, list):
+            raise LeaspyAlgoInputError(
+                f"Features need to a be a list and not : {type(self.features).__name__}"
+            )
+        if len(self.features) == 0:
+            raise LeaspyAlgoInputError("List can't be empty")
+        
+        for i, feature in enumerate(self.features):
+            if not isinstance(feature, str):
+                raise LeaspyAlgoInputError(
+                    f"Invalide feature at position {i}: need to be a string. "
+                    f"And not : {type(feature).__name__}"
+                )
+            if not feature.strip():
+                raise LeaspyAlgoInputError(f"Empty feature at the position {i}")
+
+    def _check_params(self, requirements):
+        missing_params = []
+        type_errors = []
+        value_errors = []
+
+        for param, expected_types in requirements:
+            if param not in self.param_study:
+                missing_params.append(param)
+                continue
+            value = self.param_study[param]
+            if not isinstance(value, expected_types):
+                type_names = [t.__name__ for t in expected_types] if isinstance(expected_types, tuple) else expected_types.__name__
+                type_errors.append(
+                    f"Parameter '{param}': Expected type {type_names}, given {type(value).__name__}"
+                )
+            if param == 'pat_nb' and value <= 0:
+                value_errors.append("Patient number (pat_nb) need to be a positive integer")
+                
+            if param.endswith('_std') and value < 0:
+                value_errors.append(f"Standard deviation ({param}) can't be negative")
+
+        errors = []
+        if missing_params:
+            errors.append(f"Missing parameters : {', '.join(missing_params)}")
+        if type_errors:
+            errors.append("Type problems :\n- " + "\n- ".join(type_errors))
+        if value_errors:
+            errors.append("Invalid value :\n- " + "\n- ".join(value_errors))
+
+        if errors:
+            raise LeaspyAlgoInputError("\n".join(errors))
+
+    def _validate_algo_parameters(self):
+        self._check_visit_type()
+        self._check_features()
+        
+        requirements = self._PARAM_REQUIREMENTS.get(self.visit_type)
+        if not requirements:
+            raise LeaspyAlgoInputError(f"No configuration for this type of visit '{self.visit_type}'")
+        
+        self._check_params(requirements)
+
+        if self.visit_type == "dataframe":
+            df = self.param_study["df_visits"]
+            if "ID" not in df.columns or "TIME" not in df.columns:
+                raise LeaspyAlgoInputError("Dataframe needs to have columns 'ID' and 'TIME'")
+            
+            if df["TIME"].isnull().any():
+                raise LeaspyAlgoInputError("Dataframe has null value in column TIME")
+
+
 
     ## --- SET PARAMETERS ---
     def load_parameters(self, dict_param):
@@ -98,7 +216,7 @@ class SimulationAlgorithm(AbstractAlgo):
         df_sim = self.generate_dataset(dict_timepoints, df_ip_rm)
 
         simulated_data = Data.from_dataframe(df_sim)
-        # result_obj = Result(data = simulated_data, 
+        # result_obj = Result(data = simulated_data,
         #                     individual_parameters = df_ip_rm,
         #                     noise_std = noise_std_used,
         # )

--- a/src/leaspy/algo/simulate/simulate.py
+++ b/src/leaspy/algo/simulate/simulate.py
@@ -363,25 +363,30 @@ class SimulationAlgorithm(AbstractAlgo):
             #if np.isscalar(self.param_rm["parameters"]["noise_std"]):
             if model.parameters["noise_std"].numel() == 1:
                 mu = df_long[feat + "_no_noise"]
-                #var = self.param_rm["parameters"]["noise_std"] ** 2
-                var = model.parameters["noise_std"].numpy() * 1000
+                var = model.parameters["noise_std"].numpy() ** 2
+                #var = model.parameters["noise_std"].numpy()
             else:
                 mu = df_long[feat + "_no_noise"]
-                #var = self.param_rm["parameters"]["noise_std"][i] ** 2
-                var = model.parameters["noise_std"][i].numpy() * 1000
+                var = model.parameters["noise_std"][i].numpy() ** 2
+                #var = model.parameters["noise_std"][i].numpy()
 
             # Mean and sample size (P-E simulations)
             #alpha_param = mu * var
             #beta_param = (1 - mu) * var
 
             # Mean and variance parametrization
-            #alpha_param = mu * ((mu * (1 - mu) / var) - 1)
-            #beta_param = (1 - mu) * ((mu * (1 - mu) / var) - 1)
+            alpha_param = mu * ((mu * (1 - mu) / var) - 1)
+            beta_param = (1 - mu) * ((mu * (1 - mu) / var) - 1)
 
             # Mode and concentration parametrization
-            alpha_param = mu * (var - 2) + 1
-            beta_param = (1 - mu) * (var - 2) + 1
-            df_long[feat] = beta.rvs(alpha_param, beta_param)
+            # alpha_param = mu * (var - 2) + 1
+            # beta_param = (1 - mu) * (var - 2) + 1
+
+            # Add noise for values in the right range
+            invalid_mask = (alpha_param < 0) | (beta_param < 0)
+            valid_samples = beta.rvs(alpha_param[~invalid_mask], beta_param[~invalid_mask])
+            df_long.loc[~invalid_mask, feat] = valid_samples
+
 
         dict_rm_rename = {
             "tau": "RM_TAU",


### PR DESCRIPTION
## What does the code in the MR do ?
It modify several things in the simulate function:
- Inputs are now lightened: only `seed`, `features` and `visit_parameters`. 
I moved the visit_type into `visit_parameters`, and removed all the `parameters_rm`, which were linked to the leaspy model. I can get them directly with `model.parameters` (easier for the user).
- Outputs are now in the `Result()` object form. 
- It is not a dataframe that the user get in output, but a `Data` object. He needs to do classicaly `simulated_data.data.to_dataframe` to get the simulated df.
- Adaptation of the code to tensors (really useful? I feel that I am sometimes taking tensors to put them back to numpy directly after)
- Parameters of the beta distribution have changed : I am parametrizing with the mean and variance. The noise is added only when alpha and beta > 0. Otherwise no noise added (only for one patient in our test). 

## Where should the reviewer start ?
The reviewer can read the simulate.py file first.

How can the code be tested ?
Tests are not implemented for now.

TO DO
- Tests (unittests)
- Discussion about the beta distribution parameters (comparison to the beta parameters used by P-E and Juliette in their simulations) -> why for this patient, it doesn't work (mu really close to 1 anyway, so adding noise isn't possible?)
- Seed : I don't understand why, when I change the seed, it still gives the same scores...
- I left a lot of commented code just to keep some tracks (especially when I changed to tensors). When confirmed, we need to delete these parts.

