### PR TITLE
Use dataset.event_time_name instead of hardcoded 'EVENT_TIME'

### DIFF
--- a/src/leaspy/models/joint.py
+++ b/src/leaspy/models/joint.py
@@ -337,7 +337,7 @@ class JointModel(LogisticMultivariateModel):
 
         # Set the right initialisation point fpr barrier methods
         df_inter = pd.concat(
-            [df["EVENT_TIME"] - self.init_tolerance, df_ind["tau"]], axis=1
+            [df[dataset.event_time_name] - self.init_tolerance, df_ind["tau"]], axis=1
         )
         df_ind["tau"] = df_inter.min(axis=1)
 


### PR DESCRIPTION
Replace the hardcoded string "EVENT_TIME" with the dynamic attribute dataset.event_time_name. Improves flexibility by allowing the code to work with datasets that may use different event time column names.