### PR TITLE
extend gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,9 @@ venv.bak/
 
 # mkdocs documentation
 /site
+docs/auto_examples/
+docs/sg_execution_times.rst
+examples/_outputs/
 
 # mypy
 .mypy_cache/


### PR DESCRIPTION
After the last changes (#328) related to examples in Leaspy documentary, rendering documentation creates directory and some output folders because of the fit algorithm. This PR adds these changes to .gitignore file in order to ignore them in git when we render the doc locally. 