### PR TITLE
Add references page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ user_guide
 auto_examples/index.rst
 glossary
 notations
+references
 changelog
 license
 ```

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,7 @@
+# References
+
+This page contains all the scientific references of the documentation.
+
+```{bibliography} references.bib
+:style: plain
+```


### PR DESCRIPTION
This PR proposes to add a reference page compiling all scientific references of Leaspy.
Since we have a centralized way to manage those (the `references.bib` file), it's pretty straightforward to do.

It can be visualized here: https://leaspy--391.org.readthedocs.build/en/391/references.html