### PR TITLE
Add `ModelInterface`

### DIFF
--- a/src/leaspy/models/__init__.py
+++ b/src/leaspy/models/__init__.py
@@ -1,4 +1,4 @@
-from .base import BaseModel
+from .base import BaseModel, ModelInterface
 from .constant import ConstantModel
 from .factory import ModelName, model_factory
 from .joint import JointModel
@@ -15,6 +15,7 @@ from .stateless import StatelessModel
 from .time_reparametrized import TimeReparametrizedModel
 
 __all__ = [
+    "ModelInterface",
     "ModelName",
     "McmcSaemCompatibleModel",
     "TimeReparametrizedModel",

--- a/src/leaspy/models/constant.py
+++ b/src/leaspy/models/constant.py
@@ -40,7 +40,7 @@ class ConstantModel(StatelessModel):
 
     def __init__(self, name: str, **kwargs):
         super().__init__(name, **kwargs)
-        self.is_initialized = True
+        self._is_initialized = True
 
     @property
     def hyperparameters(self) -> DictParamsTorch:

--- a/tests/unit_tests/models/test_time_reparametrized_model.py
+++ b/tests/unit_tests/models/test_time_reparametrized_model.py
@@ -36,7 +36,7 @@ class TimeReparametrizedModelTest(ManifoldModelTestMixin):
         self.assertEqual(model.source_dimension, None)
 
     def test_bad_initialize_features_dimension_inconsistent(self):
-        with self.assertRaisesRegex(ValueError, "Cannot set the model"):
+        with self.assertRaises(LeaspyModelInputError):
             TimeReparametrizedModel("dummy", features=["x", "y"], dimension=3)
 
     def test_bad_initialize_source_dim(self):


### PR DESCRIPTION
Closes #381 

This PR adds `ModelInterface` which contains the Leaspy models public interface.
The `BaseModel` implements parts of this interface and let further implementations to child classes. 
Technically, a user manipulating a model shouldn't use anything else than what is defined in this interface. 