### PR TITLE
clean docstrings of models.time_reparametrized.py

### DIFF
--- a/src/leaspy/models/time_reparametrized.py
+++ b/src/leaspy/models/time_reparametrized.py
@@ -134,7 +134,7 @@ class TimeReparametrizedModel(McmcSaemCompatibleModel):
 
         Parameters
         ----------
-        source_dimension : Optional[int], default=None
+        source_dimension : Optional[:obj:`int`], default=None
             The candidate source dimension to validate.
 
         Returns


### PR DESCRIPTION
Clean docstrings of models.time_reparametrized.py as discussed in issue #122 