### PR TITLE
Add Covariate Model 

### DIFF
--- a/docs/sg_execution_times.rst
+++ b/docs/sg_execution_times.rst
@@ -6,7 +6,7 @@
 
 Computation times
 =================
-**00:41.837** total execution time for 1 file **from all galleries**:
+**00:39.529** total execution time for 1 file **from all galleries**:
 
 .. container::
 
@@ -33,5 +33,5 @@ Computation times
      - Time
      - Mem (MB)
    * - :ref:`sphx_glr_auto_examples_plot_quickstart.py` (``../examples/plot_quickstart.py``)
-     - 00:41.837
+     - 00:39.529
      - 0.0

--- a/src/leaspy/algo/fit/fit_output_manager.py
+++ b/src/leaspy/algo/fit/fit_output_manager.py
@@ -103,7 +103,7 @@ class FitOutputManager:
 
         if self.periodicity_save is not None:
             if iteration == 0 or iteration % self.periodicity_save == 0:
-                self.save_plot_patient_reconstructions(iteration, model, data)
+                # self.save_plot_patient_reconstructions(iteration, model, data)
                 self.save_model_parameters_convergence(iteration, model)
 
         if self.periodicity_plot is not None:

--- a/src/leaspy/io/data/factory.py
+++ b/src/leaspy/io/data/factory.py
@@ -28,6 +28,25 @@ class DataframeDataReaderNames(Enum):
 
     @classmethod
     def from_string(cls, reader_name: str):
+        """
+        Returns the enum member corresponding to the given string.
+
+        Parameters
+        ----------
+        reader_name : :obj:`str`
+            The name of the reader, case-insensitive.
+
+        Returns
+        -------
+        :class:`~leaspy.io.data.factory.DataframeDataReaderNames`
+            The corresponding enum member.
+
+        Raises
+        ------
+        :exc:`NotImplementedError`
+            If the provided `reader_name` does not match any of the enum members and is not implemented.
+            Give the valid names in the error message.
+        """
         try:
             return cls(reader_name.lower())
         except ValueError:
@@ -57,8 +76,8 @@ def dataframe_data_reader_factory(
 
     Parameters
     ----------
-    model : :obj:`str` or :class:`.ObservationModel` or :obj:`dict` [ :obj:`str`, ...]
-        - If an instance of a subclass of :class:`.ObservationModel`, returns the instance.
+    model : :obj:`str` or :class:`~leaspy.models.obs_models` or :obj:`dict` [ :obj:`str`, ...]
+        - If :class:`~leaspy.models.obs_models`, returns the instance.
         - If a string, then returns a new instance of the appropriate class (with optional parameters `kws`).
         - If a dictionary, it must contain the 'name' key and other initialization parameters.
     **kwargs
@@ -66,7 +85,7 @@ def dataframe_data_reader_factory(
 
     Returns
     -------
-    :class:`.ObservationModel` :
+    :class:`~leaspy.io.data.abstract_dataframe_data_reader.AbstractDataframeDataReader`
         The desired observation model.
 
     Raises

--- a/src/leaspy/models/__init__.py
+++ b/src/leaspy/models/__init__.py
@@ -1,5 +1,10 @@
 from .base import BaseModel, ModelInterface
 from .constant import ConstantModel
+from .covariate_riemanian_manifold import (
+    CovariateLogisticModel,
+    CovariateRiemanianManifoldModel,
+)
+from .covariate_time_reparametrized import CovariateTimeReparametrizedModel
 from .factory import ModelName, model_factory
 from .joint import JointModel
 from .lme import LMEModel
@@ -32,4 +37,7 @@ __all__ = [
     "LinearModel",
     "SharedSpeedLogisticModel",
     "JointModel",
+    "CovariateTimeReparametrizedModel",
+    "CovariateRiemannianManifoldModel",
+    "CovariateLogisticModel",
 ]

--- a/src/leaspy/models/__init__.py
+++ b/src/leaspy/models/__init__.py
@@ -4,7 +4,12 @@ from .covariate_riemanian_manifold import (
     CovariateLogisticModel,
     CovariateRiemanianManifoldModel,
 )
+from .covariate_riemanian_manifold_Schiratti import (
+    CovariateLogisticModelSchiratti,
+    CovariateRiemanianManifoldModelSchiratti,
+)
 from .covariate_time_reparametrized import CovariateTimeReparametrizedModel
+from .covariate_time_reparametrized_Schiratti import CovariateTimeReparametrizedModelSchiratti
 from .factory import ModelName, model_factory
 from .joint import JointModel
 from .lme import LMEModel
@@ -14,17 +19,23 @@ from .riemanian_manifold import (
     LogisticModel,
     RiemanianManifoldModel,
 )
+from .riemanian_manifold_Schiratti import (
+    LogisticModelSchiratti,
+    RiemanianManifoldModelSchiratti,
+)
 from .settings import ModelSettings
 from .shared_speed_logistic import SharedSpeedLogisticModel
 from .stateful import StatefulModel
 from .stateless import StatelessModel
 from .time_reparametrized import TimeReparametrizedModel
+from .time_reparametrized_Schiratti import TimeReparametrizedModelSchiratti
 
 __all__ = [
     "ModelInterface",
     "ModelName",
     "McmcSaemCompatibleModel",
     "TimeReparametrizedModel",
+    "TimeReparametrizedModelSchiratti",
     "BaseModel",
     "ConstantModel",
     "StatelessModel",
@@ -33,11 +44,16 @@ __all__ = [
     "model_factory",
     "ModelSettings",
     "RiemanianManifoldModel",
+    "RiemanianManifoldModelSchiratti",
     "LogisticModel",
+    "LogisticModelSchiratti",
     "LinearModel",
     "SharedSpeedLogisticModel",
     "JointModel",
     "CovariateTimeReparametrizedModel",
-    "CovariateRiemannianManifoldModel",
+    "CovariateTimeReparametrizedModelSchiratti",
+    "CovariateRiemanianManifoldModel",
+    "CovariateRiemanianManifoldModelSchiratti",
     "CovariateLogisticModel",
+    "CovariateLogisticModelSchiratti",
 ]

--- a/src/leaspy/models/covariate_riemanian_manifold.py
+++ b/src/leaspy/models/covariate_riemanian_manifold.py
@@ -11,7 +11,7 @@ from leaspy.utils.weighted_tensor import (
     WeightedTensor,
     unsqueeze_right,
 )
-from leaspy.variables.distributions import BivariateNormal, Normal
+from leaspy.variables.distributions import BivariateNormalPop, Normal
 from leaspy.variables.specs import (
     Hyperparameter,
     LinkedVariable,
@@ -171,7 +171,7 @@ class CovariateRiemanianManifoldModel(CovariateTimeReparametrizedModel):
             xi_mean=Hyperparameter(0.0),
             # LATENT VARS
             phi_v0=PopulationLatentVariable(
-                BivariateNormal("phi_v0_mean", "phi_v0_std", "rho_v0")
+                BivariateNormalPop("phi_v0_mean", "phi_v0_std", "rho_v0")
             ),  # phi_v0 = (phi_mod_v0, phi_ref_v0)
             # LINKED VARS
             unique_covariates=LinkedVariable(Unique("covariates")),
@@ -328,7 +328,7 @@ class CovariateLogisticModel(
             rho_g=ModelParameter.for_pop_coeff_corr(("phi_g"), shape=(self.dimension,)),
             # LATENT VARS
             phi_g=PopulationLatentVariable(
-                BivariateNormal("phi_g_mean", "phi_g_std", "rho_g")
+                BivariateNormalPop("phi_g_mean", "phi_g_std", "rho_g")
             ),  # phi_g = (phi_mod_g, phi_ref_g)
             # LINKED VARS
             log_g=LinkedVariable(

--- a/src/leaspy/models/covariate_riemanian_manifold.py
+++ b/src/leaspy/models/covariate_riemanian_manifold.py
@@ -11,7 +11,7 @@ from leaspy.utils.weighted_tensor import (
     WeightedTensor,
     unsqueeze_right,
 )
-from leaspy.variables.distributions import BivariateNormalPop, Normal
+from leaspy.variables.distributions import BivariateNormal, BivariateNormalPop, Normal
 from leaspy.variables.specs import (
     Hyperparameter,
     LinkedVariable,
@@ -70,28 +70,25 @@ class CovariateRiemanianManifoldModel(CovariateTimeReparametrizedModel):
             "g",
             "v0",
             "noise_std",
-            "phi_tau",
-            "phi_g",
-            "phi_v0",
-            "rho_tau",
-            "rho_g",
-            "rho_v0",
-            "phi_v0_mean",
             "phi_tau_mean",
-            # "tau_mean",
-            # "tau_std",
             "xi_mean",
             "xi_std",
             "nll_attach",
             "nll_regul_phi_g",
             "nll_regul_phi_v0",
-            # "nll_regul_log_g",
-            # "nll_regul_log_v0",
             "xi",
             "tau",
             "nll_regul_pop_sum",
             "nll_regul_all_sum",
             "nll_tot",
+            "rho_g",
+            "rho_v0",
+            "rho_tau",
+            "phi_tau",
+            "phi_v0_mean",
+            "phi_v0",
+            "phi_g_mean",
+            "phi_g",
         ]
         if self.source_dimension:
             default_variables_to_track += [
@@ -171,7 +168,7 @@ class CovariateRiemanianManifoldModel(CovariateTimeReparametrizedModel):
             xi_mean=Hyperparameter(0.0),
             # LATENT VARS
             phi_v0=PopulationLatentVariable(
-                BivariateNormalPop("phi_v0_mean", "phi_v0_std", "rho_v0")
+                BivariateNormal("phi_v0_mean", "phi_v0_std", "rho_v0")
             ),  # phi_v0 = (phi_mod_v0, phi_ref_v0)
             # LINKED VARS
             unique_covariates=LinkedVariable(Unique("covariates")),
@@ -328,7 +325,7 @@ class CovariateLogisticModel(
             rho_g=ModelParameter.for_pop_coeff_corr(("phi_g"), shape=(self.dimension,)),
             # LATENT VARS
             phi_g=PopulationLatentVariable(
-                BivariateNormalPop("phi_g_mean", "phi_g_std", "rho_g")
+                BivariateNormal("phi_g_mean", "phi_g_std", "rho_g")
             ),  # phi_g = (phi_mod_g, phi_ref_g)
             # LINKED VARS
             log_g=LinkedVariable(

--- a/src/leaspy/models/covariate_riemanian_manifold.py
+++ b/src/leaspy/models/covariate_riemanian_manifold.py
@@ -1,0 +1,414 @@
+from abc import abstractmethod
+from typing import Iterable, Optional
+
+import pandas as pd
+import torch
+
+from leaspy.io.data.dataset import Dataset
+from leaspy.utils.functional import AffineFromVector, Exp, OrthoBasisBatch, Sqr, Unique
+from leaspy.utils.weighted_tensor import (
+    TensorOrWeightedTensor,
+    WeightedTensor,
+    unsqueeze_right,
+)
+from leaspy.variables.distributions import BivariateNormal, Normal
+from leaspy.variables.specs import (
+    Hyperparameter,
+    LinkedVariable,
+    ModelParameter,
+    NamedVariables,
+    PopulationLatentVariable,
+    SuffStatsRW,
+    VariableName,
+    VariableNameToValueMapping,
+)
+from leaspy.variables.state import State
+
+from .base import InitializationMethod
+from .covariate_time_reparametrized import CovariateTimeReparametrizedModel
+from .obs_models import FullGaussianObservationModel
+
+# TODO refact? implement a single function
+# compute_individual_tensorized(..., with_jacobian: bool) -> returning either
+# model values or model values + jacobians wrt individual parameters
+
+# TODO refact? subclass or other proper code technique to extract model's concrete
+#  formulation depending on if linear, logistic, mixed log-lin, ...
+
+
+__all__ = [
+    "CovariateRiemanianManifoldModel",
+    "CovariateLogisticInitializationMixin",
+    "CovariateLogisticModel",
+]
+
+
+class CovariateRiemanianManifoldModel(CovariateTimeReparametrizedModel):
+    """Manifold model for multiple variables of interest (logistic or linear formulation).
+
+    Parameters
+    ----------
+    name : :obj:`str`
+        The name of the model.
+    **kwargs
+        Hyperparameters of the model (including `noise_model`)
+
+    Raises
+    ------
+    :exc:`.LeaspyModelInputError`
+        * If hyperparameters are inconsistent
+    """
+
+    def __init__(
+        self,
+        name: str,
+        variables_to_track: Optional[Iterable[VariableName]] = None,
+        **kwargs,
+    ):
+        super().__init__(name, **kwargs)
+        default_variables_to_track = [
+            "g",
+            "v0",
+            "noise_std",
+            "phi_tau",
+            "phi_g",
+            "phi_v0",
+            "rho_tau",
+            "rho_g",
+            "rho_v0",
+            "phi_v0_mean",
+            "phi_tau_mean",
+            # "tau_mean",
+            # "tau_std",
+            "xi_mean",
+            "xi_std",
+            "nll_attach",
+            "nll_regul_phi_g",
+            "nll_regul_phi_v0",
+            # "nll_regul_log_g",
+            # "nll_regul_log_v0",
+            "xi",
+            "tau",
+            "nll_regul_pop_sum",
+            "nll_regul_all_sum",
+            "nll_tot",
+        ]
+        if self.source_dimension:
+            default_variables_to_track += [
+                "sources",
+                "betas",
+                "mixing_matrix",
+                "space_shifts",
+            ]
+        self.track_variables(variables_to_track or default_variables_to_track)
+
+    @classmethod
+    def _center_xi_realizations(cls, state: State) -> None:
+        """
+        Center the ``xi`` realizations in place.
+
+        .. note::
+            This operation does not change the orthonormal basis
+            (since the resulting ``v0`` is collinear to the previous one)
+            Nor all model computations (only ``v0 * exp(xi_i)`` matters),
+            it is only intended for model identifiability / ``xi_i`` regularization
+            <!> all operations are performed in "log" space (``v0`` is log'ed)
+
+        Parameters
+        ----------
+        realizations : :class:`.CollectionRealization`
+            The realizations to use for updating the :term:`MCMC` toolbox.
+        """
+        mean_xi = torch.mean(state["xi"])
+        state["xi"] = state["xi"] - mean_xi
+        state["log_v0"].add_(mean_xi.view(1, 1))
+
+        # TODO: find a way to prevent re-computation of orthonormal basis since it should
+        #  not have changed (v0_collinear update)
+        # self.update_MCMC_toolbox({'v0_collinear'}, realizations)
+
+    @classmethod
+    def compute_sufficient_statistics(cls, state: State) -> SuffStatsRW:
+        """
+        Compute the model's :term:`sufficient statistics`.
+
+        Parameters
+        ----------
+        state : :class:`.State`
+            The state to pick values from.
+
+        Returns
+        -------
+        SuffStatsRW :
+            The computed sufficient statistics.
+        """
+        # <!> modify 'xi' and 'log_v0' realizations in-place
+        # TODO: what theoretical guarantees for this custom operation?
+        cls._center_xi_realizations(state)
+
+        return super().compute_sufficient_statistics(state)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables, derived variables,
+        model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        NamedVariables :
+            The specifications of the model's variables.
+        """
+        d = super().get_variables_specs()
+        d.update(
+            # PRIORS
+            phi_v0_mean=ModelParameter.for_pop_mean(
+                ("phi_v0"), shape=(self.dimension, 2)
+            ),
+            phi_v0_std=Hyperparameter((0.001, 0.01)),
+            rho_v0=ModelParameter.for_pop_coeff_corr(
+                ("phi_v0"), shape=(self.dimension,)
+            ),
+            xi_mean=Hyperparameter(0.0),
+            # LATENT VARS
+            phi_v0=PopulationLatentVariable(
+                BivariateNormal("phi_v0_mean", "phi_v0_std", "rho_v0")
+            ),  # phi_v0 = (phi_mod_v0, phi_ref_v0)
+            # LINKED VARS
+            unique_covariates=LinkedVariable(Unique("covariates")),
+            log_v0=LinkedVariable(AffineFromVector("phi_v0", "unique_covariates")),
+            v0=LinkedVariable(Exp("log_v0")),
+            metric=LinkedVariable(
+                self.metric
+            ),  # for linear model: metric & metric_sqr are fixed = 1.
+        )
+        if self.source_dimension >= 1:
+            d.update(
+                model=LinkedVariable(self.model_with_sources_covariate),
+                metric_sqr=LinkedVariable(Sqr("metric")),
+                orthonormal_basis=LinkedVariable(OrthoBasisBatch("v0", "metric_sqr")),
+            )
+        else:
+            raise NotImplementedError(
+                "Covariate models without sources (source_dimension == 0) are not implemented yet. "
+                "Please ensure source_dimension >= 1 for CovariateRiemanianManifoldModel."
+            )
+
+        # TODO: WIP
+        # variables_info.update(self.get_additional_ordinal_population_random_variable_information())
+        # self.update_ordinal_population_random_variable_information(variables_info)
+
+        return d
+
+    @staticmethod
+    @abstractmethod
+    def metric(*, g: torch.Tensor) -> torch.Tensor:
+        pass
+
+    # @classmethod
+    # def model_no_sources(cls, *, rt: torch.Tensor, metric, v0, g) -> torch.Tensor:
+    #     """Returns a model without source. A bit dirty?"""
+    #     return cls.model_with_sources(
+    #         rt=rt,
+    #         metric=metric,
+    #         v0=v0,
+    #         g=g,
+    #         space_shifts=torch.zeros((1, 1)),
+    #     )
+
+    @classmethod
+    @abstractmethod
+    def model_with_sources_covariate(
+        cls,
+        *,
+        rt: torch.Tensor,
+        space_shifts: torch.Tensor,
+        metric,
+        v0,
+        g,
+        index_cov,
+    ) -> torch.Tensor:
+        pass
+
+
+class CovariateLogisticInitializationMixin:
+    def _compute_initial_values_for_model_parameters(
+        self,
+        dataset: Dataset,
+    ) -> VariableNameToValueMapping:
+        """Compute initial values for model parameters."""
+        from leaspy.models.utilities import (
+            compute_patient_slopes_distribution,
+            compute_patient_time_distribution,
+            compute_patient_values_distribution,
+            get_log_velocities,
+            torch_round,
+        )
+
+        df = dataset.to_pandas(apply_headers=True)
+        slopes_mu, slopes_sigma = compute_patient_slopes_distribution(df)
+        values_mu, values_sigma = compute_patient_values_distribution(df)
+        time_mu, time_sigma = compute_patient_time_distribution(df)
+
+        if self.initialization_method == InitializationMethod.DEFAULT:
+            slopes = slopes_mu
+            values = values_mu
+            t0 = time_mu
+            betas = torch.zeros((self.dimension - 1, self.source_dimension))
+
+        if self.initialization_method == InitializationMethod.RANDOM:
+            slopes = torch.normal(slopes_mu, slopes_sigma)
+            values = torch.normal(values_mu, values_sigma)
+            t0 = torch.normal(time_mu, time_sigma)
+            betas = torch.distributions.normal.Normal(loc=0.0, scale=1.0).sample(
+                sample_shape=(self.dimension - 1, self.source_dimension)
+            )
+
+        # Enforce values are between 0 and 1
+        values = values.clamp(min=1e-2, max=1 - 1e-2)
+
+        parameters = {
+            "phi_tau_mean": torch.Tensor([1.0, t0]),
+            "phi_g_mean": torch.stack(
+                [
+                    torch.full((self.dimension,), 0.01),  # slopes
+                    torch.log(1.0 / values - 1.0),  # intercepts (logit)
+                ],
+                dim=0,
+            ).T,
+            "phi_v0_mean": torch.stack(
+                [
+                    torch.full((self.dimension,), 0.01),  # slopes
+                    get_log_velocities(slopes, self.features),  # intercepts
+                ],
+                dim=0,
+            ).T,
+            "rho_tau": torch.zeros(1),
+            "rho_g": torch.zeros(self.dimension),
+            "rho_v0": torch.zeros(self.dimension),
+            "xi_std": self.xi_std,
+        }
+        if self.source_dimension >= 1:
+            parameters["betas_mean"] = betas
+        rounded_parameters = {
+            str(p): torch_round(v.to(torch.float32)) for p, v in parameters.items()
+        }
+        obs_model = next(iter(self.obs_models))  # WIP: multiple obs models...
+        if isinstance(obs_model, FullGaussianObservationModel):
+            rounded_parameters["noise_std"] = self.noise_std.expand(
+                obs_model.extra_vars["noise_std"].shape
+            )
+        return rounded_parameters
+
+
+class CovariateLogisticModel(
+    CovariateLogisticInitializationMixin, CovariateRiemanianManifoldModel
+):
+    """Manifold model for multiple variables of interest (logistic formulation)."""
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__(name, **kwargs)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables, derived variables,
+        model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        NamedVariables :
+            The specifications of the model's variables.
+        """
+        d = super().get_variables_specs()
+        d.update(
+            # PRIORS
+            phi_g_mean=ModelParameter.for_pop_mean(
+                ("phi_g"), shape=(self.dimension, 2)
+            ),
+            phi_g_std=Hyperparameter((0.001, 0.01)),
+            rho_g=ModelParameter.for_pop_coeff_corr(("phi_g"), shape=(self.dimension,)),
+            # LATENT VARS
+            phi_g=PopulationLatentVariable(
+                BivariateNormal("phi_g_mean", "phi_g_std", "rho_g")
+            ),  # phi_g = (phi_mod_g, phi_ref_g)
+            # LINKED VARS
+            log_g=LinkedVariable(
+                AffineFromVector("phi_g", "unique_covariates")
+            ),  # log_g=phi_mod_g*covariate+phi_ref_g
+            g=LinkedVariable(Exp("log_g")),
+        )
+
+        return d
+
+    @staticmethod
+    def metric(*, g: torch.Tensor) -> torch.Tensor:
+        """Used to define the corresponding variable."""
+        return (g + 1) ** 2 / g
+
+    # @classmethod
+    # def model_with_sources(
+    #     cls,
+    #     *,
+    #     rt: TensorOrWeightedTensor[float],
+    #     space_shifts: TensorOrWeightedTensor[float],
+    #     metric: TensorOrWeightedTensor[float],
+    #     v0: TensorOrWeightedTensor[float],
+    #     g: TensorOrWeightedTensor[float],
+    # ) -> torch.Tensor:
+    #     """Returns a model with sources."""
+    #     # Shape: (Ni, Nt, Nfts)
+    #     pop_s = (None, None, ...)
+    #     rt = unsqueeze_right(rt, ndim=1)  # .filled(float('nan'))
+    #     w_model_logit = metric[pop_s] * (
+    #         v0[pop_s] * rt + space_shifts[:, None, ...]
+    #     ) - torch.log(g[pop_s])
+    #     model_logit, weights = WeightedTensor.get_filled_value_and_weight(
+    #         w_model_logit, fill_value=0.0
+    #     )
+    #     return WeightedTensor(torch.sigmoid(model_logit), weights).weighted_value
+
+    @classmethod
+    def model_with_sources_covariate(
+        cls,
+        *,
+        rt: TensorOrWeightedTensor[float],
+        space_shifts: TensorOrWeightedTensor[float],
+        metric: TensorOrWeightedTensor[float],
+        v0: TensorOrWeightedTensor[float],
+        g: TensorOrWeightedTensor[float],
+        index_cov: TensorOrWeightedTensor[int],
+    ) -> torch.Tensor:
+        """
+        Returns a model with sources, accounting for covariates.
+
+        Parameters
+        ----------
+        rt : (Ni, Nt)
+        space_shifts : (Ni, K)
+        metric, v0, g : (K, Nc)
+        index_cov : (Ni,) — index of covariate group per individual
+
+        Returns
+        -------
+        Tensor : (Ni, Nt, K)
+        """
+        pop_s = (None, None, ...)  # for broadcasting
+
+        # Get relevant covariate column per individual
+        metric_n = metric[:, index_cov]  # shape: (K, N)
+        v0_n = v0[:, index_cov]  # shape: (K, N)
+        g_n = g[:, index_cov]  # shape: (K, N)
+
+        # Transpose to (N, K)
+        metric_n = metric_n.T  # shape: (N, K)
+        v0_n = v0_n.T
+        g_n = g_n.T
+
+        rt = unsqueeze_right(rt, ndim=1)  # .filled(float('nan'))
+        w_model_logit = metric_n[:, None, :] * (
+            v0_n[:, None, :] * rt + space_shifts[:, None, ...]
+        ) - torch.log(g_n[:, None, :])
+
+        model_logit, weights = WeightedTensor.get_filled_value_and_weight(
+            w_model_logit, fill_value=0.0
+        )
+        return WeightedTensor(torch.sigmoid(model_logit), weights).weighted_value

--- a/src/leaspy/models/covariate_riemanian_manifold.py
+++ b/src/leaspy/models/covariate_riemanian_manifold.py
@@ -5,7 +5,15 @@ import pandas as pd
 import torch
 
 from leaspy.io.data.dataset import Dataset
-from leaspy.utils.functional import AffineFromVector, Exp, OrthoBasisBatch, Sqr, Unique
+from leaspy.utils.functional import (
+    AffineFromVector,
+    CorrCoeff,
+    Cov,
+    Exp,
+    OrthoBasisBatch,
+    Sqr,
+    Unique,
+)
 from leaspy.utils.weighted_tensor import (
     TensorOrWeightedTensor,
     WeightedTensor,
@@ -71,6 +79,7 @@ class CovariateRiemanianManifoldModel(CovariateTimeReparametrizedModel):
             "v0",
             "noise_std",
             "phi_tau_mean",
+            "phi_tau_std",
             "xi_mean",
             "xi_std",
             "nll_attach",
@@ -89,6 +98,9 @@ class CovariateRiemanianManifoldModel(CovariateTimeReparametrizedModel):
             "phi_v0",
             "phi_g_mean",
             "phi_g",
+            "cov_g",
+            "cov_v0",
+            "cov_tau",
         ]
         if self.source_dimension:
             default_variables_to_track += [
@@ -162,13 +174,16 @@ class CovariateRiemanianManifoldModel(CovariateTimeReparametrizedModel):
                 ("phi_v0"), shape=(self.dimension, 2)
             ),
             phi_v0_std=Hyperparameter((0.001, 0.01)),
-            rho_v0=ModelParameter.for_pop_coeff_corr(
-                ("phi_v0"), shape=(self.dimension,)
-            ),
+            # rho_v0=ModelParameter.for_pop_coeff_corr(
+            #     ("phi_v0"), shape=(self.dimension,)
+            # ),
+            # cov_v0=LinkedVariable(Cov("rho_v0", "phi_v0_std")),
+            cov_v0=ModelParameter.for_pop_cov(("phi_v0"), shape=(self.dimension,)),
+            rho_v0=LinkedVariable(CorrCoeff("cov_v0", "phi_v0_std")),
             xi_mean=Hyperparameter(0.0),
             # LATENT VARS
             phi_v0=PopulationLatentVariable(
-                BivariateNormal("phi_v0_mean", "phi_v0_std", "rho_v0")
+                BivariateNormalPop("phi_v0_mean", "phi_v0_std", "cov_v0")
             ),  # phi_v0 = (phi_mod_v0, phi_ref_v0)
             # LINKED VARS
             unique_covariates=LinkedVariable(Unique("covariates")),
@@ -267,21 +282,22 @@ class CovariateLogisticInitializationMixin:
             "phi_tau_mean": torch.Tensor([1.0, t0]),
             "phi_g_mean": torch.stack(
                 [
-                    torch.full((self.dimension,), 0.01),  # slopes
+                    torch.full((self.dimension,), 1),  # slopes
                     torch.log(1.0 / values - 1.0),  # intercepts (logit)
                 ],
                 dim=0,
             ).T,
             "phi_v0_mean": torch.stack(
                 [
-                    torch.full((self.dimension,), 0.01),  # slopes
+                    torch.full((self.dimension,), 1),  # slopes
                     get_log_velocities(slopes, self.features),  # intercepts
                 ],
                 dim=0,
             ).T,
-            "rho_tau": torch.zeros(1),
-            "rho_g": torch.zeros(self.dimension),
-            "rho_v0": torch.zeros(self.dimension),
+            "cov_tau": torch.zeros(1),
+            "cov_g": torch.zeros(self.dimension),
+            "cov_v0": torch.zeros(self.dimension),
+            "phi_tau_std": self.phi_tau_std,
             "xi_std": self.xi_std,
         }
         if self.source_dimension >= 1:
@@ -322,10 +338,13 @@ class CovariateLogisticModel(
                 ("phi_g"), shape=(self.dimension, 2)
             ),
             phi_g_std=Hyperparameter((0.001, 0.01)),
-            rho_g=ModelParameter.for_pop_coeff_corr(("phi_g"), shape=(self.dimension,)),
+            # rho_g=ModelParameter.for_pop_coeff_corr(("phi_g"), shape=(self.dimension,)),
+            # cov_g=LinkedVariable(Cov("rho_g","phi_g_std")),
+            cov_g=ModelParameter.for_pop_cov(("phi_g"), shape=(self.dimension,)),
+            rho_g=LinkedVariable(CorrCoeff("cov_g", "phi_g_std")),
             # LATENT VARS
             phi_g=PopulationLatentVariable(
-                BivariateNormal("phi_g_mean", "phi_g_std", "rho_g")
+                BivariateNormalPop("phi_g_mean", "phi_g_std", "cov_g")
             ),  # phi_g = (phi_mod_g, phi_ref_g)
             # LINKED VARS
             log_g=LinkedVariable(

--- a/src/leaspy/models/covariate_riemanian_manifold_Schiratti.py
+++ b/src/leaspy/models/covariate_riemanian_manifold_Schiratti.py
@@ -1,0 +1,434 @@
+from abc import abstractmethod
+from typing import Iterable, Optional
+
+import pandas as pd
+import torch
+
+from leaspy.io.data.dataset import Dataset
+from leaspy.utils.functional import (
+    AffineFromVector,
+    CorrCoeff,
+    Cov,
+    Exp,
+    OrthoBasisBatch,
+    Sqr,
+    Unique,
+)
+from leaspy.utils.weighted_tensor import (
+    TensorOrWeightedTensor,
+    WeightedTensor,
+    unsqueeze_right,
+)
+from leaspy.variables.distributions import BivariateNormal, BivariateNormalPop, Normal
+from leaspy.variables.specs import (
+    Hyperparameter,
+    LinkedVariable,
+    ModelParameter,
+    NamedVariables,
+    PopulationLatentVariable,
+    SuffStatsRW,
+    VariableName,
+    VariableNameToValueMapping,
+)
+from leaspy.variables.state import State
+
+from .base import InitializationMethod
+from .covariate_time_reparametrized_Schiratti import CovariateTimeReparametrizedModelSchiratti
+from .obs_models import FullGaussianObservationModel
+
+# TODO refact? implement a single function
+# compute_individual_tensorized(..., with_jacobian: bool) -> returning either
+# model values or model values + jacobians wrt individual parameters
+
+# TODO refact? subclass or other proper code technique to extract model's concrete
+#  formulation depending on if linear, logistic, mixed log-lin, ...
+
+
+__all__ = [
+    "CovariateRiemanianManifoldModelSchiratti",
+    "CovariateLogisticInitializationMixinSchiratti",
+    "CovariateLogisticModelSchiratti",
+]
+
+
+class CovariateRiemanianManifoldModelSchiratti(CovariateTimeReparametrizedModelSchiratti):
+    """Manifold model for multiple variables of interest (logistic or linear formulation).
+
+    Parameters
+    ----------
+    name : :obj:`str`
+        The name of the model.
+    **kwargs
+        Hyperparameters of the model (including `noise_model`)
+
+    Raises
+    ------
+    :exc:`.LeaspyModelInputError`
+        * If hyperparameters are inconsistent
+    """
+
+    def __init__(
+        self,
+        name: str,
+        variables_to_track: Optional[Iterable[VariableName]] = None,
+        **kwargs,
+    ):
+        super().__init__(name, **kwargs)
+        default_variables_to_track = [
+            "t0",
+            "g",
+            "v0",
+            "noise_std",
+            "phi_t0_mean",
+            "tau_mean",
+            "tau_std",
+            "xi_mean",
+            "xi_std",
+            "nll_attach",
+            "nll_regul_phi_g",
+            "nll_regul_phi_v0",
+            "nll_regul_phi_t0",
+            "xi",
+            "tau",
+            "nll_regul_pop_sum",
+            "nll_regul_all_sum",
+            "nll_tot",
+            "rho_g",
+            "rho_v0",
+            "rho_t0",
+            "phi_t0",
+            "phi_v0_mean",
+            "phi_v0",
+            "phi_g_mean",
+            "phi_g",
+            "cov_g",
+            "cov_v0",
+            "cov_t0",
+        ]
+        if self.source_dimension:
+            default_variables_to_track += [
+                "sources",
+                "betas",
+                "mixing_matrix",
+                "space_shifts",
+            ]
+        self.track_variables(variables_to_track or default_variables_to_track)
+
+    @classmethod
+    def _center_xi_realizations(cls, state: State) -> None:
+        """
+        Center the ``xi`` realizations in place.
+
+        .. note::
+            This operation does not change the orthonormal basis
+            (since the resulting ``v0`` is collinear to the previous one)
+            Nor all model computations (only ``v0 * exp(xi_i)`` matters),
+            it is only intended for model identifiability / ``xi_i`` regularization
+            <!> all operations are performed in "log" space (``v0`` is log'ed)
+
+        Parameters
+        ----------
+        realizations : :class:`.CollectionRealization`
+            The realizations to use for updating the :term:`MCMC` toolbox.
+        """
+        mean_xi = torch.mean(state["xi"])
+        state["xi"] = state["xi"] - mean_xi
+        state["log_v0"].add_(mean_xi.view(1, 1))
+
+        # TODO: find a way to prevent re-computation of orthonormal basis since it should
+        #  not have changed (v0_collinear update)
+        # self.update_MCMC_toolbox({'v0_collinear'}, realizations)
+
+    @classmethod
+    def compute_sufficient_statistics(cls, state: State) -> SuffStatsRW:
+        """
+        Compute the model's :term:`sufficient statistics`.
+
+        Parameters
+        ----------
+        state : :class:`.State`
+            The state to pick values from.
+
+        Returns
+        -------
+        SuffStatsRW :
+            The computed sufficient statistics.
+        """
+        # <!> modify 'xi' and 'log_v0' realizations in-place
+        # TODO: what theoretical guarantees for this custom operation?
+        cls._center_xi_realizations(state)
+
+        return super().compute_sufficient_statistics(state)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables, derived variables,
+        model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        NamedVariables :
+            The specifications of the model's variables.
+        """
+        d = super().get_variables_specs()
+        d.update(
+            # PRIORS
+            phi_v0_mean=ModelParameter.for_pop_mean(
+                ("phi_v0"), shape=(self.dimension, 2)
+            ),
+            phi_v0_std=Hyperparameter((0.001, 0.01)),
+            # rho_v0=ModelParameter.for_pop_coeff_corr(
+            #     ("phi_v0"), shape=(self.dimension,)
+            # ),
+            # cov_v0=LinkedVariable(Cov("rho_v0", "phi_v0_std")),
+            cov_v0=ModelParameter.for_pop_cov(("phi_v0"), shape=(self.dimension,)),
+            rho_v0=LinkedVariable(CorrCoeff("cov_v0", "phi_v0_std")),
+            xi_mean=Hyperparameter(0.0),
+            # LATENT VARS
+            phi_v0=PopulationLatentVariable(
+                BivariateNormalPop("phi_v0_mean", "phi_v0_std", "cov_v0")
+            ),  # phi_v0 = (phi_mod_v0, phi_ref_v0)
+            # LINKED VARS
+            unique_covariates=LinkedVariable(Unique("covariates")),
+            log_v0=LinkedVariable(AffineFromVector("phi_v0", "unique_covariates")),
+            v0=LinkedVariable(Exp("log_v0")),
+            metric=LinkedVariable(
+                self.metric
+            ),  # for linear model: metric & metric_sqr are fixed = 1.
+        )
+        if self.source_dimension >= 1:
+            d.update(
+                model=LinkedVariable(self.model_with_sources_covariate),
+                metric_sqr=LinkedVariable(Sqr("metric")),
+                orthonormal_basis=LinkedVariable(OrthoBasisBatch("v0", "metric_sqr")),
+            )
+        else:
+            raise NotImplementedError(
+                "Covariate models without sources (source_dimension == 0) are not implemented yet. "
+                "Please ensure source_dimension >= 1 for CovariateRiemanianManifoldModel."
+            )
+
+        # TODO: WIP
+        # variables_info.update(self.get_additional_ordinal_population_random_variable_information())
+        # self.update_ordinal_population_random_variable_information(variables_info)
+
+        return d
+
+    @staticmethod
+    @abstractmethod
+    def metric(*, g: torch.Tensor) -> torch.Tensor:
+        pass
+
+    # @classmethod
+    # def model_no_sources(cls, *, rt: torch.Tensor, metric, v0, g) -> torch.Tensor:
+    #     """Returns a model without source. A bit dirty?"""
+    #     return cls.model_with_sources(
+    #         rt=rt,
+    #         metric=metric,
+    #         v0=v0,
+    #         g=g,
+    #         space_shifts=torch.zeros((1, 1)),
+    #     )
+
+    @classmethod
+    @abstractmethod
+    def model_with_sources_covariate(
+        cls,
+        *,
+        rt: torch.Tensor,
+        space_shifts: torch.Tensor,
+        metric,
+        v0,
+        g,
+        index_cov,
+    ) -> torch.Tensor:
+        pass
+
+
+class CovariateLogisticInitializationMixinSchiratti:
+    def _compute_initial_values_for_model_parameters(
+        self,
+        dataset: Dataset,
+    ) -> VariableNameToValueMapping:
+        """Compute initial values for model parameters."""
+        from leaspy.models.utilities import (
+            compute_patient_slopes_distribution,
+            compute_patient_time_distribution,
+            compute_patient_values_distribution,
+            get_log_velocities,
+            torch_round,
+        )
+
+        df = dataset.to_pandas(apply_headers=True)
+        slopes_mu, slopes_sigma = compute_patient_slopes_distribution(df)
+        values_mu, values_sigma = compute_patient_values_distribution(df)
+        time_mu, time_sigma = compute_patient_time_distribution(df)
+
+        if self.initialization_method == InitializationMethod.DEFAULT:
+            slopes = slopes_mu
+            values = values_mu
+            t0 = time_mu
+            betas = torch.zeros((self.dimension - 1, self.source_dimension))
+
+        if self.initialization_method == InitializationMethod.RANDOM:
+            slopes = torch.normal(slopes_mu, slopes_sigma)
+            values = torch.normal(values_mu, values_sigma)
+            t0 = torch.normal(time_mu, time_sigma)
+            betas = torch.distributions.normal.Normal(loc=0.0, scale=1.0).sample(
+                sample_shape=(self.dimension - 1, self.source_dimension)
+            )
+
+        # Enforce values are between 0 and 1
+        values = values.clamp(min=1e-2, max=1 - 1e-2)
+
+        parameters = {
+            "phi_t0_mean": torch.Tensor([1.0, t0]),
+            "phi_g_mean": torch.stack(
+                [
+                    torch.full((self.dimension,), 1),  # slopes
+                    torch.log(1.0 / values - 1.0),  # intercepts (logit)
+                ],
+                dim=0,
+            ).T,
+            "phi_v0_mean": torch.stack(
+                [
+                    torch.full((self.dimension,), 1),  # slopes
+                    get_log_velocities(slopes, self.features),  # intercepts
+                ],
+                dim=0,
+            ).T,
+            "cov_t0": torch.zeros(1),
+            "cov_g": torch.zeros(self.dimension),
+            "cov_v0": torch.zeros(self.dimension),
+            "tau_std": self.tau_std,
+            "xi_std": self.xi_std,
+        }
+        if self.source_dimension >= 1:
+            parameters["betas_mean"] = betas
+        rounded_parameters = {
+            str(p): torch_round(v.to(torch.float32)) for p, v in parameters.items()
+        }
+        obs_model = next(iter(self.obs_models))  # WIP: multiple obs models...
+        if isinstance(obs_model, FullGaussianObservationModel):
+            rounded_parameters["noise_std"] = self.noise_std.expand(
+                obs_model.extra_vars["noise_std"].shape
+            )
+        return rounded_parameters
+
+
+class CovariateLogisticModelSchiratti(
+    CovariateLogisticInitializationMixinSchiratti,
+    CovariateRiemanianManifoldModelSchiratti,
+):
+    """Manifold model for multiple variables of interest (logistic formulation)."""
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__(name, **kwargs)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables, derived variables,
+        model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        NamedVariables :
+            The specifications of the model's variables.
+        """
+        d = super().get_variables_specs()
+        d.update(
+            # PRIORS
+            phi_g_mean=ModelParameter.for_pop_mean(
+                ("phi_g"), shape=(self.dimension, 2)
+            ),
+            phi_g_std=Hyperparameter((0.001, 0.01)),
+            # rho_g=ModelParameter.for_pop_coeff_corr(("phi_g"), shape=(self.dimension,)),
+            # cov_g=LinkedVariable(Cov("rho_g","phi_g_std")),
+            cov_g=ModelParameter.for_pop_cov(("phi_g"), shape=(self.dimension,)),
+            rho_g=LinkedVariable(CorrCoeff("cov_g", "phi_g_std")),
+            # LATENT VARS
+            phi_g=PopulationLatentVariable(
+                BivariateNormalPop("phi_g_mean", "phi_g_std", "cov_g")
+            ),  # phi_g = (phi_mod_g, phi_ref_g)
+            # LINKED VARS
+            log_g=LinkedVariable(
+                AffineFromVector("phi_g", "unique_covariates")
+            ),  # log_g=phi_mod_g*covariate+phi_ref_g
+            g=LinkedVariable(Exp("log_g")),
+        )
+
+        return d
+
+    @staticmethod
+    def metric(*, g: torch.Tensor) -> torch.Tensor:
+        """Used to define the corresponding variable."""
+        return (g + 1) ** 2 / g
+
+    # @classmethod
+    # def model_with_sources(
+    #     cls,
+    #     *,
+    #     rt: TensorOrWeightedTensor[float],
+    #     space_shifts: TensorOrWeightedTensor[float],
+    #     metric: TensorOrWeightedTensor[float],
+    #     v0: TensorOrWeightedTensor[float],
+    #     g: TensorOrWeightedTensor[float],
+    # ) -> torch.Tensor:
+    #     """Returns a model with sources."""
+    #     # Shape: (Ni, Nt, Nfts)
+    #     pop_s = (None, None, ...)
+    #     rt = unsqueeze_right(rt, ndim=1)  # .filled(float('nan'))
+    #     w_model_logit = metric[pop_s] * (
+    #         v0[pop_s] * rt + space_shifts[:, None, ...]
+    #     ) - torch.log(g[pop_s])
+    #     model_logit, weights = WeightedTensor.get_filled_value_and_weight(
+    #         w_model_logit, fill_value=0.0
+    #     )
+    #     return WeightedTensor(torch.sigmoid(model_logit), weights).weighted_value
+
+    @classmethod
+    def model_with_sources_covariate(
+        cls,
+        *,
+        rt: TensorOrWeightedTensor[float],
+        space_shifts: TensorOrWeightedTensor[float],
+        metric: TensorOrWeightedTensor[float],
+        v0: TensorOrWeightedTensor[float],
+        g: TensorOrWeightedTensor[float],
+        index_cov: TensorOrWeightedTensor[int],
+    ) -> torch.Tensor:
+        """
+        Returns a model with sources, accounting for covariates.
+
+        Parameters
+        ----------
+        rt : (Ni, Nt)
+        space_shifts : (Ni, K)
+        metric, v0, g : (K, Nc)
+        index_cov : (Ni,) — index of covariate group per individual
+
+        Returns
+        -------
+        Tensor : (Ni, Nt, K)
+        """
+        pop_s = (None, None, ...)  # for broadcasting
+
+        # Get relevant covariate column per individual
+        metric_n = metric[:, index_cov]  # shape: (K, N)
+        v0_n = v0[:, index_cov]  # shape: (K, N)
+        g_n = g[:, index_cov]  # shape: (K, N)
+
+        # Transpose to (N, K)
+        metric_n = metric_n.T  # shape: (N, K)
+        v0_n = v0_n.T
+        g_n = g_n.T
+
+        rt = unsqueeze_right(rt, ndim=1)  # .filled(float('nan'))
+        w_model_logit = metric_n[:, None, :] * (
+            v0_n[:, None, :] * rt + space_shifts[:, None, ...]
+        ) - torch.log(g_n[:, None, :])
+
+        model_logit, weights = WeightedTensor.get_filled_value_and_weight(
+            w_model_logit, fill_value=0.0
+        )
+        return WeightedTensor(torch.sigmoid(model_logit), weights).weighted_value

--- a/src/leaspy/models/covariate_time_reparametrized.py
+++ b/src/leaspy/models/covariate_time_reparametrized.py
@@ -1,0 +1,490 @@
+import warnings
+from typing import Optional, Union
+
+import torch
+
+from leaspy.exceptions import LeaspyIndividualParamsInputError, LeaspyModelInputError
+from leaspy.io.data.dataset import Dataset
+from leaspy.utils.functional import (
+    AffineFromVector,
+    BatchMatMulByIndex,
+    Exp,
+    IndexOf,
+    MatMul,
+)
+from leaspy.utils.typing import DictParams, DictParamsTorch, FeatureType, KwargsType
+from leaspy.utils.weighted_tensor import TensorOrWeightedTensor, WeightedTensor
+from leaspy.variables.distributions import BivariateNormal, Normal
+from leaspy.variables.specs import (
+    DataVariable,
+    Hyperparameter,
+    IndividualLatentVariable,
+    LatentVariableInitType,
+    LinkedVariable,
+    ModelParameter,
+    NamedVariables,
+    PopulationLatentVariable,
+)
+from leaspy.variables.state import State
+
+from .mcmc_saem_compatible import McmcSaemCompatibleModel
+from .obs_models import observation_model_factory
+
+__all__ = ["CovariateTimeReparametrizedModel"]
+
+
+class CovariateTimeReparametrizedModel(McmcSaemCompatibleModel):
+    """
+    Contains the common attributes & methods of the multivariate models.
+
+    Parameters
+    ----------
+    name : :obj:`str`
+        Name of the model.
+    **kwargs
+        Hyperparameters for the model (including `obs_models`).
+
+    Raises
+    ------
+    :exc:`.LeaspyModelInputError`
+        If inconsistent hyperparameters.
+    """
+
+    _xi_std = 0.5
+    _tau_std = 5.0
+    _noise_std = 0.1
+    _sources_std = 1.0
+
+    def __init__(
+        self,
+        name: str,
+        source_dimension: Optional[int] = None,
+        **kwargs,
+    ):
+        # TODO / WIP / TMP: dirty for now...
+        # Should we:
+        # - use factory of observation models instead? dataset -> ObservationModel
+        # - or refact a bit `ObservationModel` structure? (lazy init of its variables...)
+        # (cf. note in AbstractModel as well)
+        dimension = kwargs.get("dimension", None)
+        if "features" in kwargs:
+            dimension = len(kwargs["features"])
+        # source_dimension = kwargs.get("source_dimension", None)
+        # if dimension == 1 and source_dimension not in {0, None}:
+        #    raise LeaspyModelInputError(
+        #        "You should not provide `source_dimension` != 0 for univariate model."
+        #    )
+        # self.source_dimension: Optional[int] = source_dimension
+        observation_models = kwargs.get("obs_models", None)
+        if observation_models is None:
+            observation_models = (
+                "gaussian-scalar" if dimension is None else "gaussian-diagonal"
+            )
+        if isinstance(observation_models, (list, tuple)):
+            kwargs["obs_models"] = tuple(
+                [
+                    observation_model_factory(obs_model, **kwargs)
+                    for obs_model in observation_models
+                ]
+            )
+        elif isinstance(observation_models, dict):
+            # Not really satisfied... Used for api load
+            kwargs["obs_models"] = tuple(
+                [
+                    observation_model_factory(
+                        observation_models["y"], dimension=dimension
+                    )
+                ]
+            )
+        else:
+            kwargs["obs_models"] = (
+                observation_model_factory(observation_models, dimension=dimension),
+            )
+        super().__init__(name, **kwargs)
+        self._source_dimension = self._validate_source_dimension(source_dimension)
+
+    @property
+    def xi_std(self) -> torch.Tensor:
+        return torch.tensor([self._xi_std])
+
+    @property
+    def tau_std(self) -> torch.Tensor:
+        return torch.tensor([self._tau_std])
+
+    @property
+    def noise_std(self) -> torch.Tensor:
+        return torch.tensor(self._noise_std)
+
+    @property
+    def sources_std(self) -> float:
+        return self._sources_std
+
+    @property
+    def source_dimension(self) -> Optional[int]:
+        return self._source_dimension
+
+    @source_dimension.setter
+    def source_dimension(self, source_dimension: Optional[int] = None):
+        self._source_dimension = self._validate_source_dimension(source_dimension)
+
+    def _validate_source_dimension(self, source_dimension: Optional[int] = None) -> int:
+        if self.dimension == 1:
+            return 0
+        if source_dimension is not None:
+            if not isinstance(source_dimension, int):
+                raise LeaspyModelInputError(
+                    f"`source_dimension` must be an integer, not {type(source_dimension)}"
+                )
+            if source_dimension < 0:
+                raise LeaspyModelInputError(
+                    f"`source_dimension` must be >= 0, you provided {source_dimension}"
+                )
+            if self.dimension is not None and source_dimension > self.dimension - 1:
+                raise LeaspyModelInputError(
+                    f"Source dimension should be within [0, {self.dimension - 1}], "
+                    f"you provided {source_dimension}"
+                )
+        return source_dimension
+
+    @property
+    def has_sources(self) -> bool:
+        return (
+            hasattr(self, "source_dimension")
+            and isinstance(self.source_dimension, int)
+            and self.source_dimension > 0
+        )
+
+    @staticmethod
+    def time_reparametrization(
+        *,
+        t: TensorOrWeightedTensor[float],
+        alpha: torch.Tensor,
+        tau: torch.Tensor,
+    ) -> TensorOrWeightedTensor[float]:
+        """
+        Tensorized time reparametrization formula.
+
+        .. warning::
+            Shapes of tensors must be compatible between them.
+
+        Parameters
+        ----------
+        t : :class:`torch.Tensor`
+            Timepoints to reparametrize
+        alpha : :class:`torch.Tensor`
+            Acceleration factors of individual(s)
+        tau : :class:`torch.Tensor`
+            Time-shift(s).
+
+        Returns
+        -------
+        :class:`torch.Tensor` of same shape as `timepoints`
+        """
+        return alpha * (t - tau)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables,
+        derived variables, model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        NamedVariables :
+            The specifications of the model's variables.
+        """
+        specifications = super().get_variables_specs()
+        specifications.update(
+            rt=LinkedVariable(self.time_reparametrization),
+            # INPUTS
+            covariates=DataVariable(),
+            # PRIORS
+            phi_tau_mean=ModelParameter.for_ind_mean(
+                ("phi_tau"), shape=(2,)
+            ),  # (phi_mod_tau_mean, phi_ref_tau_mean)
+            phi_tau_std=Hyperparameter((0.001, 0.01)),
+            rho_tau=ModelParameter.for_ind_coeff_corr(("phi_tau"), shape=(1,)),
+            xi_std=ModelParameter.for_ind_std("xi", shape=(1,)),
+            # LATENT VARS
+            xi=IndividualLatentVariable(Normal("xi_mean", "xi_std")),
+            phi_tau=IndividualLatentVariable(
+                BivariateNormal("phi_tau_mean", "phi_tau_std", "rho_tau")
+            ),  # phi_tau = (phi_mod_tau, phi_ref_tau)
+            # DERIVED VARS
+            tau=LinkedVariable(AffineFromVector("phi_tau", "covariates")),
+            alpha=LinkedVariable(Exp("xi")),
+        )
+        if self.source_dimension >= 1:
+            specifications.update(
+                # PRIORS
+                betas_mean=ModelParameter.for_pop_mean(
+                    "betas",
+                    shape=(self.dimension - 1, self.source_dimension),
+                ),
+                betas_std=Hyperparameter(0.01),
+                sources_mean=Hyperparameter(torch.zeros((self.source_dimension,))),
+                sources_std=Hyperparameter(1.0),
+                # LATENT VARS
+                betas=PopulationLatentVariable(
+                    Normal("betas_mean", "betas_std"),
+                    sampling_kws={"scale": 0.5},  # cf. GibbsSampler (for retro-compat)
+                ),
+                sources=IndividualLatentVariable(Normal("sources_mean", "sources_std")),
+                # DERIVED VARS
+                index_cov=LinkedVariable(IndexOf("covariates", "unique_covariates")),
+                mixing_matrix=LinkedVariable(
+                    MatMul("orthonormal_basis", "betas").then(
+                        lambda x: x.permute(0, 2, 1)
+                    )
+                ),  # shape: (Ns, Nfts)
+                space_shifts=LinkedVariable(
+                    BatchMatMulByIndex("sources", "mixing_matrix", "index_cov")
+                ),  # shape: (Ni, Nfts)
+            )
+
+        return specifications
+
+    def put_data_variables(self, state: State, dataset: Dataset) -> None:
+        super().put_data_variables(state, dataset)
+        covariates_tensor = dataset.covariates.clone().detach().to(torch.int)
+        state["covariates"] = WeightedTensor(covariates_tensor)
+
+    def _validate_compatibility_of_dataset(
+        self, dataset: Optional[Dataset] = None
+    ) -> None:
+        super()._validate_compatibility_of_dataset(dataset)
+        if not dataset:
+            return
+        if self.source_dimension is None:
+            self.source_dimension = int(dataset.dimension**0.5)
+            warnings.warn(
+                "You did not provide `source_dimension` hyperparameter for multivariate model, "
+                f"setting it to ⌊√dimension⌋ = {self.source_dimension}."
+            )
+        elif not (
+            isinstance(self.source_dimension, int)
+            and 0 <= self.source_dimension < dataset.dimension
+        ):
+            raise LeaspyModelInputError(
+                f"Sources dimension should be an integer in [0, dimension - 1[ "
+                f"but you provided `source_dimension` = {self.source_dimension} "
+                f"whereas `dimension` = {dataset.dimension}."
+            )
+
+    def _audit_individual_parameters(
+        self, individual_parameters: DictParams
+    ) -> KwargsType:
+        from .utilities import is_array_like, tensorize_2D
+
+        expected_parameters = set(["xi", "tau"] + int(self.has_sources) * ["sources"])
+        given_parameters = set(individual_parameters.keys())
+        symmetric_diff = expected_parameters.symmetric_difference(given_parameters)
+        if len(symmetric_diff) > 0:
+            raise LeaspyIndividualParamsInputError(
+                f"Individual parameters dict provided {given_parameters} "
+                f"is not compatible for {self.name} model. "
+                f"The expected individual parameters are {expected_parameters}."
+            )
+        ips_is_array_like = {
+            k: is_array_like(v) for k, v in individual_parameters.items()
+        }
+        ips_size = {
+            k: len(v) if ips_is_array_like[k] else 1
+            for k, v in individual_parameters.items()
+        }
+        if self.has_sources:
+            if not ips_is_array_like["sources"]:
+                raise LeaspyIndividualParamsInputError(
+                    f"Sources must be an array_like but {individual_parameters['sources']} was provided."
+                )
+            tau_xi_scalars = all(ips_size[k] == 1 for k in ["tau", "xi"])
+            if tau_xi_scalars and (ips_size["sources"] > 1):
+                # is 'sources' not a nested array? (allowed iff tau & xi are scalars)
+                if not is_array_like(individual_parameters["sources"][0]):
+                    # then update sources size (1D vector representing only 1 individual)
+                    ips_size["sources"] = 1
+            # TODO? check source dimension compatibility?
+        uniq_sizes = set(ips_size.values())
+        if len(uniq_sizes) != 1:
+            raise LeaspyIndividualParamsInputError(
+                f"Individual parameters sizes are not compatible together. Sizes are {ips_size}."
+            )
+        # number of individuals present
+        n_individual_parameters = uniq_sizes.pop()
+        # properly choose unsqueezing dimension when tensorizing array_like (useful for sources)
+        # [1,2] => [[1],[2]] (expected for 2 individuals / 1D sources)
+        # [1,2] => [[1,2]] (expected for 1 individual / 2D sources)
+        unsqueeze_dim = 0 if n_individual_parameters == 1 else -1
+        # tensorized (2D) version of ips
+        tensorized_individual_parameters = {
+            name: tensorize_2D(value, unsqueeze_dim=unsqueeze_dim)
+            for name, value in individual_parameters.items()
+        }
+
+        return {
+            "nb_inds": n_individual_parameters,
+            "tensorized_ips": tensorized_individual_parameters,
+            "tensorized_ips_gen": (
+                {
+                    name: value[individual, :].unsqueeze(0)
+                    for name, value in tensorized_individual_parameters.items()
+                }
+                for individual in range(n_individual_parameters)
+            ),
+        }
+
+    def _load_hyperparameters(self, hyperparameters: KwargsType) -> None:
+        """
+        Updates all model hyperparameters from the provided hyperparameters.
+
+        Parameters
+        ----------
+        hyperparameters : KwargsType
+            The hyperparameters to be loaded.
+        """
+        if "features" in hyperparameters:
+            self.features = hyperparameters["features"]
+
+        if "dimension" in hyperparameters:
+            if self.features and hyperparameters["dimension"] != len(self.features):
+                raise LeaspyModelInputError(
+                    f"Dimension provided ({hyperparameters['dimension']}) does not match "
+                    f"features ({len(self.features)})"
+                )
+            self.dimension = hyperparameters["dimension"]
+
+        if "source_dimension" in hyperparameters:
+            if not (
+                isinstance(hyperparameters["source_dimension"], int)
+                and (hyperparameters["source_dimension"] >= 0)
+                and (
+                    self.dimension is None
+                    or hyperparameters["source_dimension"] <= self.dimension - 1
+                )
+            ):
+                raise LeaspyModelInputError(
+                    f"Source dimension should be an integer in [0, dimension - 1], "
+                    f"not {hyperparameters['source_dimension']}"
+                )
+            self.source_dimension = hyperparameters["source_dimension"]
+
+    def put_individual_parameters(self, state: State, dataset: Dataset):
+        if not state.are_variables_set(("xi", "tau")):
+            with state.auto_fork(None):
+                state.put_individual_latent_variables(
+                    LatentVariableInitType.PRIOR_SAMPLES,
+                    n_individuals=dataset.n_individuals,
+                )
+
+    def to_dict(self, *, with_mixing_matrix: bool = True) -> KwargsType:
+        """
+        Export ``Leaspy`` object as dictionary ready for :term:`JSON` saving.
+
+        Parameters
+        ----------
+        with_mixing_matrix : :obj:`bool` (default ``True``)
+            Save the :term:`mixing matrix` in the exported file in its 'parameters' section.
+
+            .. warning::
+                It is not a real parameter and its value will be overwritten at model loading
+                (orthonormal basis is recomputed from other "true" parameters and mixing matrix
+                is then deduced from this orthonormal basis and the betas)!
+                It was integrated historically because it is used for convenience in
+                browser webtool and only there...
+
+        Returns
+        -------
+        KwargsType :
+            The object as a dictionary.
+        """
+        model_settings = super().to_dict()
+        model_settings["source_dimension"] = self.source_dimension
+
+        if with_mixing_matrix and self.source_dimension >= 1:
+            # transposed compared to previous version
+            model_settings["parameters"]["mixing_matrix"] = self.state[
+                "mixing_matrix"
+            ].tolist()
+
+        return model_settings
+
+    # TODO: unit tests? (functional tests covered by api.estimate)
+    def compute_individual_ages_from_biomarker_values(
+        self,
+        value: Union[float, list[float]],
+        individual_parameters: DictParams,
+        feature: Optional[FeatureType] = None,
+    ) -> torch.Tensor:
+        """
+        For one individual, compute age(s) at which the given features values
+        are reached (given the subject's individual parameters).
+
+        Consistency checks are done in the main :term:`API` layer.
+
+        Parameters
+        ----------
+        value : scalar or array_like[scalar] (:obj:`list`, :obj:`tuple`, :class:`numpy.ndarray`)
+            Contains the :term:`biomarker` value(s) of the subject.
+
+        individual_parameters : :obj:`dict`
+            Contains the individual parameters.
+            Each individual parameter should be a scalar or array_like.
+
+        feature : :obj:`str` (or None)
+            Name of the considered :term:`biomarker`.
+
+            .. note::
+                Optional for :class:`.UnivariateModel`, compulsory
+                for :class:`.MultivariateModel`.
+
+        Returns
+        -------
+        :class:`torch.Tensor`
+            Contains the subject's ages computed at the given values(s).
+            Shape of tensor is ``(1, n_values)``.
+
+        Raises
+        ------
+        :exc:`.LeaspyModelInputError`
+            If computation is tried on more than 1 individual.
+        """
+        # value, individual_parameters = self._get_tensorized_inputs(
+        #     value, individual_parameters, skip_ips_checks=False
+        # )
+        # return self.compute_individual_ages_from_biomarker_values_tensorized(
+        #     value, individual_parameters, feature
+        # )
+        raise NotImplementedError("This method is currently not implemented.")
+
+    def compute_individual_ages_from_biomarker_values_tensorized(
+        self,
+        value: torch.Tensor,
+        individual_parameters: DictParamsTorch,
+        feature: Optional[FeatureType],
+    ) -> torch.Tensor:
+        """
+        For one individual, compute age(s) at which the given features values are
+        reached (given the subject's individual parameters), with tensorized inputs.
+
+        Parameters
+        ----------
+        value : :class:`torch.Tensor` of shape ``(1, n_values)``
+            Contains the :term:`biomarker` value(s) of the subject.
+
+        individual_parameters : DictParamsTorch
+            Contains the individual parameters.
+            Each individual parameter should be a :class:`torch.Tensor`.
+
+        feature : :obj:`str` (or None)
+            Name of the considered :term:`biomarker`.
+
+            .. note::
+                Optional for :class:`.UnivariateModel`, compulsory
+                for :class:`.MultivariateModel`.
+
+        Returns
+        -------
+        :class:`torch.Tensor`
+            Contains the subject's ages computed at the given values(s).
+            Shape of tensor is ``(n_values, 1)``.
+        """
+        raise NotImplementedError("This method is currently not implemented.")

--- a/src/leaspy/models/covariate_time_reparametrized.py
+++ b/src/leaspy/models/covariate_time_reparametrized.py
@@ -201,7 +201,7 @@ class CovariateTimeReparametrizedModel(McmcSaemCompatibleModel):
             phi_tau_mean=ModelParameter.for_ind_mean(
                 ("phi_tau"), shape=(2,)
             ),  # (phi_mod_tau_mean, phi_ref_tau_mean)
-            phi_tau_std=Hyperparameter((0.001, 0.01)),
+            phi_tau_std=Hyperparameter((0.01, 0.1)),
             rho_tau=ModelParameter.for_ind_coeff_corr(("phi_tau"), shape=(1,)),
             xi_std=ModelParameter.for_ind_std("xi", shape=(1,)),
             # LATENT VARS

--- a/src/leaspy/models/covariate_time_reparametrized.py
+++ b/src/leaspy/models/covariate_time_reparametrized.py
@@ -14,7 +14,7 @@ from leaspy.utils.functional import (
 )
 from leaspy.utils.typing import DictParams, DictParamsTorch, FeatureType, KwargsType
 from leaspy.utils.weighted_tensor import TensorOrWeightedTensor, WeightedTensor
-from leaspy.variables.distributions import BivariateNormal, Normal
+from leaspy.variables.distributions import BivariateNormalInd, Normal
 from leaspy.variables.specs import (
     DataVariable,
     Hyperparameter,
@@ -201,13 +201,13 @@ class CovariateTimeReparametrizedModel(McmcSaemCompatibleModel):
             phi_tau_mean=ModelParameter.for_ind_mean(
                 ("phi_tau"), shape=(2,)
             ),  # (phi_mod_tau_mean, phi_ref_tau_mean)
-            phi_tau_std=Hyperparameter((0.01, 0.1)),
+            phi_tau_std=Hyperparameter((1, 10)),
             rho_tau=ModelParameter.for_ind_coeff_corr(("phi_tau"), shape=(1,)),
             xi_std=ModelParameter.for_ind_std("xi", shape=(1,)),
             # LATENT VARS
             xi=IndividualLatentVariable(Normal("xi_mean", "xi_std")),
             phi_tau=IndividualLatentVariable(
-                BivariateNormal("phi_tau_mean", "phi_tau_std", "rho_tau")
+                BivariateNormalInd("phi_tau_mean", "phi_tau_std", "rho_tau")
             ),  # phi_tau = (phi_mod_tau, phi_ref_tau)
             # DERIVED VARS
             tau=LinkedVariable(AffineFromVector("phi_tau", "covariates")),

--- a/src/leaspy/models/covariate_time_reparametrized.py
+++ b/src/leaspy/models/covariate_time_reparametrized.py
@@ -14,7 +14,7 @@ from leaspy.utils.functional import (
 )
 from leaspy.utils.typing import DictParams, DictParamsTorch, FeatureType, KwargsType
 from leaspy.utils.weighted_tensor import TensorOrWeightedTensor, WeightedTensor
-from leaspy.variables.distributions import BivariateNormalInd, Normal
+from leaspy.variables.distributions import BivariateNormal, BivariateNormalInd, Normal
 from leaspy.variables.specs import (
     DataVariable,
     Hyperparameter,
@@ -201,13 +201,13 @@ class CovariateTimeReparametrizedModel(McmcSaemCompatibleModel):
             phi_tau_mean=ModelParameter.for_ind_mean(
                 ("phi_tau"), shape=(2,)
             ),  # (phi_mod_tau_mean, phi_ref_tau_mean)
-            phi_tau_std=Hyperparameter((1, 10)),
+            phi_tau_std=Hyperparameter((0.1, 1)),
             rho_tau=ModelParameter.for_ind_coeff_corr(("phi_tau"), shape=(1,)),
             xi_std=ModelParameter.for_ind_std("xi", shape=(1,)),
             # LATENT VARS
             xi=IndividualLatentVariable(Normal("xi_mean", "xi_std")),
             phi_tau=IndividualLatentVariable(
-                BivariateNormalInd("phi_tau_mean", "phi_tau_std", "rho_tau")
+                BivariateNormal("phi_tau_mean", "phi_tau_std", "rho_tau")
             ),  # phi_tau = (phi_mod_tau, phi_ref_tau)
             # DERIVED VARS
             tau=LinkedVariable(AffineFromVector("phi_tau", "covariates")),

--- a/src/leaspy/models/covariate_time_reparametrized.py
+++ b/src/leaspy/models/covariate_time_reparametrized.py
@@ -8,6 +8,8 @@ from leaspy.io.data.dataset import Dataset
 from leaspy.utils.functional import (
     AffineFromVector,
     BatchMatMulByIndex,
+    CorrCoeff,
+    Cov,
     Exp,
     IndexOf,
     MatMul,
@@ -51,7 +53,7 @@ class CovariateTimeReparametrizedModel(McmcSaemCompatibleModel):
     """
 
     _xi_std = 0.5
-    _tau_std = 5.0
+    _phi_tau_std = [0.1, 5.0]
     _noise_std = 0.1
     _sources_std = 1.0
 
@@ -108,8 +110,8 @@ class CovariateTimeReparametrizedModel(McmcSaemCompatibleModel):
         return torch.tensor([self._xi_std])
 
     @property
-    def tau_std(self) -> torch.Tensor:
-        return torch.tensor([self._tau_std])
+    def phi_tau_std(self) -> torch.Tensor:
+        return torch.tensor(self._phi_tau_std)
 
     @property
     def noise_std(self) -> torch.Tensor:
@@ -201,13 +203,17 @@ class CovariateTimeReparametrizedModel(McmcSaemCompatibleModel):
             phi_tau_mean=ModelParameter.for_ind_mean(
                 ("phi_tau"), shape=(2,)
             ),  # (phi_mod_tau_mean, phi_ref_tau_mean)
-            phi_tau_std=Hyperparameter((0.1, 1)),
-            rho_tau=ModelParameter.for_ind_coeff_corr(("phi_tau"), shape=(1,)),
+            # phi_tau_std=Hyperparameter((1, 10)),
+            phi_tau_std=ModelParameter.for_ind_std("phi_tau", shape=(2,)),
+            # rho_tau=ModelParameter.for_ind_coeff_corr(("phi_tau"), shape=(1,)),
+            # cov_tau=LinkedVariable(Cov("rho_tau", "phi_tau_std")),
+            cov_tau=ModelParameter.for_ind_cov(("phi_tau"), shape=(1,)),
+            rho_tau=LinkedVariable(CorrCoeff("cov_tau", "phi_tau_std")),
             xi_std=ModelParameter.for_ind_std("xi", shape=(1,)),
             # LATENT VARS
             xi=IndividualLatentVariable(Normal("xi_mean", "xi_std")),
             phi_tau=IndividualLatentVariable(
-                BivariateNormal("phi_tau_mean", "phi_tau_std", "rho_tau")
+                BivariateNormalInd("phi_tau_mean", "phi_tau_std", "cov_tau")
             ),  # phi_tau = (phi_mod_tau, phi_ref_tau)
             # DERIVED VARS
             tau=LinkedVariable(AffineFromVector("phi_tau", "covariates")),

--- a/src/leaspy/models/covariate_time_reparametrized_Schiratti.py
+++ b/src/leaspy/models/covariate_time_reparametrized_Schiratti.py
@@ -1,0 +1,531 @@
+import warnings
+from typing import Optional, Union
+
+import torch
+
+from leaspy.exceptions import LeaspyIndividualParamsInputError, LeaspyModelInputError
+from leaspy.io.data.dataset import Dataset
+from leaspy.utils.functional import (
+    AffineFromVector,
+    BatchMatMulByIndex,
+    CorrCoeff,
+    Cov,
+    Exp,
+    IndexOf,
+    MatMul,
+)
+from leaspy.utils.typing import DictParams, DictParamsTorch, FeatureType, KwargsType
+from leaspy.utils.weighted_tensor import TensorOrWeightedTensor, WeightedTensor
+from leaspy.variables.distributions import BivariateNormal, BivariateNormalPop, Normal
+from leaspy.variables.specs import (
+    DataVariable,
+    Hyperparameter,
+    IndividualLatentVariable,
+    LatentVariableInitType,
+    LinkedVariable,
+    ModelParameter,
+    NamedVariables,
+    PopulationLatentVariable,
+)
+from leaspy.variables.state import State
+
+from .mcmc_saem_compatible import McmcSaemCompatibleModel
+from .obs_models import observation_model_factory
+
+__all__ = ["CovariateTimeReparametrizedModelSchiratti"]
+
+
+class CovariateTimeReparametrizedModelSchiratti(McmcSaemCompatibleModel):
+    """
+    Contains the common attributes & methods of the multivariate models.
+
+    Parameters
+    ----------
+    name : :obj:`str`
+        Name of the model.
+    **kwargs
+        Hyperparameters for the model (including `obs_models`).
+
+    Raises
+    ------
+    :exc:`.LeaspyModelInputError`
+        If inconsistent hyperparameters.
+    """
+
+    _xi_std = 0.5
+    _tau_std = 5.0
+    _noise_std = 0.1
+    _sources_std = 1.0
+
+    def __init__(
+        self,
+        name: str,
+        source_dimension: Optional[int] = None,
+        **kwargs,
+    ):
+        # TODO / WIP / TMP: dirty for now...
+        # Should we:
+        # - use factory of observation models instead? dataset -> ObservationModel
+        # - or refact a bit `ObservationModel` structure? (lazy init of its variables...)
+        # (cf. note in AbstractModel as well)
+        dimension = kwargs.get("dimension", None)
+        if "features" in kwargs:
+            dimension = len(kwargs["features"])
+        # source_dimension = kwargs.get("source_dimension", None)
+        # if dimension == 1 and source_dimension not in {0, None}:
+        #    raise LeaspyModelInputError(
+        #        "You should not provide `source_dimension` != 0 for univariate model."
+        #    )
+        # self.source_dimension: Optional[int] = source_dimension
+        observation_models = kwargs.get("obs_models", None)
+        if observation_models is None:
+            observation_models = (
+                "gaussian-scalar" if dimension is None else "gaussian-diagonal"
+            )
+        if isinstance(observation_models, (list, tuple)):
+            kwargs["obs_models"] = tuple(
+                [
+                    observation_model_factory(obs_model, **kwargs)
+                    for obs_model in observation_models
+                ]
+            )
+        elif isinstance(observation_models, dict):
+            # Not really satisfied... Used for api load
+            kwargs["obs_models"] = tuple(
+                [
+                    observation_model_factory(
+                        observation_models["y"], dimension=dimension
+                    )
+                ]
+            )
+        else:
+            kwargs["obs_models"] = (
+                observation_model_factory(observation_models, dimension=dimension),
+            )
+        super().__init__(name, **kwargs)
+        self._source_dimension = self._validate_source_dimension(source_dimension)
+
+    @property
+    def xi_std(self) -> torch.Tensor:
+        return torch.tensor([self._xi_std])
+
+    @property
+    def tau_std(self) -> torch.Tensor:
+        return torch.tensor(self._tau_std)
+
+    @property
+    def noise_std(self) -> torch.Tensor:
+        return torch.tensor(self._noise_std)
+
+    @property
+    def sources_std(self) -> float:
+        return self._sources_std
+
+    @property
+    def source_dimension(self) -> Optional[int]:
+        return self._source_dimension
+
+    @source_dimension.setter
+    def source_dimension(self, source_dimension: Optional[int] = None):
+        self._source_dimension = self._validate_source_dimension(source_dimension)
+
+    def _validate_source_dimension(self, source_dimension: Optional[int] = None) -> int:
+        if self.dimension == 1:
+            return 0
+        if source_dimension is not None:
+            if not isinstance(source_dimension, int):
+                raise LeaspyModelInputError(
+                    f"`source_dimension` must be an integer, not {type(source_dimension)}"
+                )
+            if source_dimension < 0:
+                raise LeaspyModelInputError(
+                    f"`source_dimension` must be >= 0, you provided {source_dimension}"
+                )
+            if self.dimension is not None and source_dimension > self.dimension - 1:
+                raise LeaspyModelInputError(
+                    f"Source dimension should be within [0, {self.dimension - 1}], "
+                    f"you provided {source_dimension}"
+                )
+        return source_dimension
+
+    @property
+    def has_sources(self) -> bool:
+        return (
+            hasattr(self, "source_dimension")
+            and isinstance(self.source_dimension, int)
+            and self.source_dimension > 0
+        )
+
+    @staticmethod
+    def time_reparametrization(
+        *,
+        t: TensorOrWeightedTensor[float],
+        alpha: torch.Tensor,
+        tau: torch.Tensor,
+        t0: torch.Tensor,
+        covariates: torch.Tensor,
+        unique_covariates: torch.Tensor,
+    ) -> TensorOrWeightedTensor[float]:
+        """
+        Tensorized time reparametrization formula.
+
+        .. warning::
+            Shapes of tensors must be compatible between them.
+
+        Parameters
+        ----------
+        t : :class:`torch.Tensor`
+            Timepoints to reparametrize
+        alpha : :class:`torch.Tensor`
+            Acceleration factors of individual(s)
+        tau : :class:`torch.Tensor`
+            Time-shift(s).
+
+        Returns
+        -------
+        :class:`torch.Tensor` of same shape as `timepoints`
+        """
+
+        def to_tensor(x):
+            if hasattr(x, "weighted_value"):
+                return x.weighted_value
+            if hasattr(x, "value"):
+                return x.value
+            return x
+
+        # --- extraction des tenseurs réels ---
+        t = to_tensor(t)
+        alpha = to_tensor(alpha)
+        tau = to_tensor(tau)
+        t0 = to_tensor(t0)
+        covariates = to_tensor(covariates)
+        unique_covariates = to_tensor(unique_covariates)
+
+        # On extrait les vecteurs propres
+        covars = covariates.squeeze(1)  # (N,)
+        uniq = unique_covariates  # (K,)
+        t0_vector = t0.squeeze(0)  # (K,)
+
+        # Construction du masque (N,K)
+        mask = covars.unsqueeze(1) == uniq.unsqueeze(0)
+
+        # Conversion en indices
+        indices = mask.long().argmax(dim=1)  # (N,)
+
+        # t0 pour chaque patient (N,1)
+        t0_patient = t0_vector[indices].unsqueeze(1)
+
+        # Calcul final
+        return alpha * (t - t0_patient - tau)
+        return alpha * (t - t0 - tau)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables,
+        derived variables, model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        NamedVariables :
+            The specifications of the model's variables.
+        """
+        specifications = super().get_variables_specs()
+        specifications.update(
+            rt=LinkedVariable(self.time_reparametrization),
+            # INPUTS
+            covariates=DataVariable(),
+            # PRIORS
+            phi_t0_mean=ModelParameter.for_pop_mean(
+                ("phi_t0"), shape=(1, 2)
+            ),  # (phi_mod_t0_mean, phi_ref_t0_mean)
+            phi_t0_std=Hyperparameter((0.01, 0.01)),
+            cov_t0=ModelParameter.for_pop_cov(("phi_t0"), shape=(1,)),
+            rho_t0=LinkedVariable(CorrCoeff("cov_t0", "phi_t0_std")),
+            tau_mean=Hyperparameter(0.0),
+            tau_std=ModelParameter.for_ind_std("tau", shape=(1,)),
+            xi_std=ModelParameter.for_ind_std("xi", shape=(1,)),
+            # LATENT VARS
+            tau=IndividualLatentVariable(Normal("tau_mean", "tau_std")),
+            xi=IndividualLatentVariable(Normal("xi_mean", "xi_std")),
+            phi_t0=PopulationLatentVariable(
+                BivariateNormalPop("phi_t0_mean", "phi_t0_std", "cov_t0")
+            ),  # phi_t0 = (phi_mod_t0, phi_ref_t0)
+            # DERIVED VARS
+            t0=LinkedVariable(AffineFromVector("phi_t0", "unique_covariates")),
+            alpha=LinkedVariable(Exp("xi")),
+        )
+        if self.source_dimension >= 1:
+            specifications.update(
+                # PRIORS
+                betas_mean=ModelParameter.for_pop_mean(
+                    "betas",
+                    shape=(self.dimension - 1, self.source_dimension),
+                ),
+                betas_std=Hyperparameter(0.01),
+                sources_mean=Hyperparameter(torch.zeros((self.source_dimension,))),
+                sources_std=Hyperparameter(1.0),
+                # LATENT VARS
+                betas=PopulationLatentVariable(
+                    Normal("betas_mean", "betas_std"),
+                    sampling_kws={"scale": 0.5},  # cf. GibbsSampler (for retro-compat)
+                ),
+                sources=IndividualLatentVariable(Normal("sources_mean", "sources_std")),
+                # DERIVED VARS
+                index_cov=LinkedVariable(IndexOf("covariates", "unique_covariates")),
+                mixing_matrix=LinkedVariable(
+                    MatMul("orthonormal_basis", "betas").then(
+                        lambda x: x.permute(0, 2, 1)
+                    )
+                ),  # shape: (Ns, Nfts)
+                space_shifts=LinkedVariable(
+                    BatchMatMulByIndex("sources", "mixing_matrix", "index_cov")
+                ),  # shape: (Ni, Nfts)
+            )
+
+        return specifications
+
+    def put_data_variables(self, state: State, dataset: Dataset) -> None:
+        super().put_data_variables(state, dataset)
+        covariates_tensor = dataset.covariates.clone().detach().to(torch.int)
+        state["covariates"] = WeightedTensor(covariates_tensor)
+
+    def _validate_compatibility_of_dataset(
+        self, dataset: Optional[Dataset] = None
+    ) -> None:
+        super()._validate_compatibility_of_dataset(dataset)
+        if not dataset:
+            return
+        if self.source_dimension is None:
+            self.source_dimension = int(dataset.dimension**0.5)
+            warnings.warn(
+                "You did not provide `source_dimension` hyperparameter for multivariate model, "
+                f"setting it to ⌊√dimension⌋ = {self.source_dimension}."
+            )
+        elif not (
+            isinstance(self.source_dimension, int)
+            and 0 <= self.source_dimension < dataset.dimension
+        ):
+            raise LeaspyModelInputError(
+                f"Sources dimension should be an integer in [0, dimension - 1[ "
+                f"but you provided `source_dimension` = {self.source_dimension} "
+                f"whereas `dimension` = {dataset.dimension}."
+            )
+
+    def _audit_individual_parameters(
+        self, individual_parameters: DictParams
+    ) -> KwargsType:
+        from .utilities import is_array_like, tensorize_2D
+
+        expected_parameters = set(["xi", "tau"] + int(self.has_sources) * ["sources"])
+        given_parameters = set(individual_parameters.keys())
+        symmetric_diff = expected_parameters.symmetric_difference(given_parameters)
+        if len(symmetric_diff) > 0:
+            raise LeaspyIndividualParamsInputError(
+                f"Individual parameters dict provided {given_parameters} "
+                f"is not compatible for {self.name} model. "
+                f"The expected individual parameters are {expected_parameters}."
+            )
+        ips_is_array_like = {
+            k: is_array_like(v) for k, v in individual_parameters.items()
+        }
+        ips_size = {
+            k: len(v) if ips_is_array_like[k] else 1
+            for k, v in individual_parameters.items()
+        }
+        if self.has_sources:
+            if not ips_is_array_like["sources"]:
+                raise LeaspyIndividualParamsInputError(
+                    f"Sources must be an array_like but {individual_parameters['sources']} was provided."
+                )
+            tau_xi_scalars = all(ips_size[k] == 1 for k in ["tau", "xi"])
+            if tau_xi_scalars and (ips_size["sources"] > 1):
+                # is 'sources' not a nested array? (allowed iff tau & xi are scalars)
+                if not is_array_like(individual_parameters["sources"][0]):
+                    # then update sources size (1D vector representing only 1 individual)
+                    ips_size["sources"] = 1
+            # TODO? check source dimension compatibility?
+        uniq_sizes = set(ips_size.values())
+        if len(uniq_sizes) != 1:
+            raise LeaspyIndividualParamsInputError(
+                f"Individual parameters sizes are not compatible together. Sizes are {ips_size}."
+            )
+        # number of individuals present
+        n_individual_parameters = uniq_sizes.pop()
+        # properly choose unsqueezing dimension when tensorizing array_like (useful for sources)
+        # [1,2] => [[1],[2]] (expected for 2 individuals / 1D sources)
+        # [1,2] => [[1,2]] (expected for 1 individual / 2D sources)
+        unsqueeze_dim = 0 if n_individual_parameters == 1 else -1
+        # tensorized (2D) version of ips
+        tensorized_individual_parameters = {
+            name: tensorize_2D(value, unsqueeze_dim=unsqueeze_dim)
+            for name, value in individual_parameters.items()
+        }
+
+        return {
+            "nb_inds": n_individual_parameters,
+            "tensorized_ips": tensorized_individual_parameters,
+            "tensorized_ips_gen": (
+                {
+                    name: value[individual, :].unsqueeze(0)
+                    for name, value in tensorized_individual_parameters.items()
+                }
+                for individual in range(n_individual_parameters)
+            ),
+        }
+
+    def _load_hyperparameters(self, hyperparameters: KwargsType) -> None:
+        """
+        Updates all model hyperparameters from the provided hyperparameters.
+
+        Parameters
+        ----------
+        hyperparameters : KwargsType
+            The hyperparameters to be loaded.
+        """
+        if "features" in hyperparameters:
+            self.features = hyperparameters["features"]
+
+        if "dimension" in hyperparameters:
+            if self.features and hyperparameters["dimension"] != len(self.features):
+                raise LeaspyModelInputError(
+                    f"Dimension provided ({hyperparameters['dimension']}) does not match "
+                    f"features ({len(self.features)})"
+                )
+            self.dimension = hyperparameters["dimension"]
+
+        if "source_dimension" in hyperparameters:
+            if not (
+                isinstance(hyperparameters["source_dimension"], int)
+                and (hyperparameters["source_dimension"] >= 0)
+                and (
+                    self.dimension is None
+                    or hyperparameters["source_dimension"] <= self.dimension - 1
+                )
+            ):
+                raise LeaspyModelInputError(
+                    f"Source dimension should be an integer in [0, dimension - 1], "
+                    f"not {hyperparameters['source_dimension']}"
+                )
+            self.source_dimension = hyperparameters["source_dimension"]
+
+    def put_individual_parameters(self, state: State, dataset: Dataset):
+        if not state.are_variables_set(("xi", "tau")):
+            with state.auto_fork(None):
+                state.put_individual_latent_variables(
+                    LatentVariableInitType.PRIOR_SAMPLES,
+                    n_individuals=dataset.n_individuals,
+                )
+
+    def to_dict(self, *, with_mixing_matrix: bool = True) -> KwargsType:
+        """
+        Export ``Leaspy`` object as dictionary ready for :term:`JSON` saving.
+
+        Parameters
+        ----------
+        with_mixing_matrix : :obj:`bool` (default ``True``)
+            Save the :term:`mixing matrix` in the exported file in its 'parameters' section.
+
+            .. warning::
+                It is not a real parameter and its value will be overwritten at model loading
+                (orthonormal basis is recomputed from other "true" parameters and mixing matrix
+                is then deduced from this orthonormal basis and the betas)!
+                It was integrated historically because it is used for convenience in
+                browser webtool and only there...
+
+        Returns
+        -------
+        KwargsType :
+            The object as a dictionary.
+        """
+        model_settings = super().to_dict()
+        model_settings["source_dimension"] = self.source_dimension
+
+        if with_mixing_matrix and self.source_dimension >= 1:
+            # transposed compared to previous version
+            model_settings["parameters"]["mixing_matrix"] = self.state[
+                "mixing_matrix"
+            ].tolist()
+
+        return model_settings
+
+    # TODO: unit tests? (functional tests covered by api.estimate)
+    def compute_individual_ages_from_biomarker_values(
+        self,
+        value: Union[float, list[float]],
+        individual_parameters: DictParams,
+        feature: Optional[FeatureType] = None,
+    ) -> torch.Tensor:
+        """
+        For one individual, compute age(s) at which the given features values
+        are reached (given the subject's individual parameters).
+
+        Consistency checks are done in the main :term:`API` layer.
+
+        Parameters
+        ----------
+        value : scalar or array_like[scalar] (:obj:`list`, :obj:`tuple`, :class:`numpy.ndarray`)
+            Contains the :term:`biomarker` value(s) of the subject.
+
+        individual_parameters : :obj:`dict`
+            Contains the individual parameters.
+            Each individual parameter should be a scalar or array_like.
+
+        feature : :obj:`str` (or None)
+            Name of the considered :term:`biomarker`.
+
+            .. note::
+                Optional for :class:`.UnivariateModel`, compulsory
+                for :class:`.MultivariateModel`.
+
+        Returns
+        -------
+        :class:`torch.Tensor`
+            Contains the subject's ages computed at the given values(s).
+            Shape of tensor is ``(1, n_values)``.
+
+        Raises
+        ------
+        :exc:`.LeaspyModelInputError`
+            If computation is tried on more than 1 individual.
+        """
+        # value, individual_parameters = self._get_tensorized_inputs(
+        #     value, individual_parameters, skip_ips_checks=False
+        # )
+        # return self.compute_individual_ages_from_biomarker_values_tensorized(
+        #     value, individual_parameters, feature
+        # )
+        raise NotImplementedError("This method is currently not implemented.")
+
+    def compute_individual_ages_from_biomarker_values_tensorized(
+        self,
+        value: torch.Tensor,
+        individual_parameters: DictParamsTorch,
+        feature: Optional[FeatureType],
+    ) -> torch.Tensor:
+        """
+        For one individual, compute age(s) at which the given features values are
+        reached (given the subject's individual parameters), with tensorized inputs.
+
+        Parameters
+        ----------
+        value : :class:`torch.Tensor` of shape ``(1, n_values)``
+            Contains the :term:`biomarker` value(s) of the subject.
+
+        individual_parameters : DictParamsTorch
+            Contains the individual parameters.
+            Each individual parameter should be a :class:`torch.Tensor`.
+
+        feature : :obj:`str` (or None)
+            Name of the considered :term:`biomarker`.
+
+            .. note::
+                Optional for :class:`.UnivariateModel`, compulsory
+                for :class:`.MultivariateModel`.
+
+        Returns
+        -------
+        :class:`torch.Tensor`
+            Contains the subject's ages computed at the given values(s).
+            Shape of tensor is ``(n_values, 1)``.
+        """
+        raise NotImplementedError("This method is currently not implemented.")

--- a/src/leaspy/models/factory.py
+++ b/src/leaspy/models/factory.py
@@ -3,6 +3,7 @@ from typing import Optional, Union
 
 from .base import BaseModel
 from .constant import ConstantModel
+from .covariate_riemanian_manifold import CovariateLogisticModel
 from .joint import JointModel
 from .lme import LMEModel
 from .riemanian_manifold import LinearModel, LogisticModel
@@ -23,6 +24,7 @@ class ModelName(str, Enum):
     SHARED_SPEED_LOGISTIC = "shared_speed_logistic"
     LME = "lme"
     CONSTANT = "constant"
+    COVARIATE = "covariate"
 
 
 def model_factory(
@@ -63,3 +65,5 @@ def model_factory(
         return LMEModel(instance_name, **kwargs)
     if name == ModelName.CONSTANT:
         return ConstantModel(instance_name, **kwargs)
+    if name == ModelName.COVARIATE:
+        return CovariateLogisticModel(instance_name, **kwargs)

--- a/src/leaspy/models/mcmc_saem_compatible.py
+++ b/src/leaspy/models/mcmc_saem_compatible.py
@@ -32,7 +32,7 @@ class McmcSaemCompatibleModel(StatefulModel):
     name : :obj:`str`
         The name of the model.
 
-    obs_models : ObservationModel or Iterable[ObservationModel]
+    obs_models : :class:`~leaspy.models.obs_models` or :class:`~typing.Iterable` [:class:`~leaspy.models.obs_models`]
         The noise model for observations (keyword-only parameter).
 
     fit_metrics : :obj:`dict`
@@ -48,15 +48,15 @@ class McmcSaemCompatibleModel(StatefulModel):
         Indicates if the model is initialized.
     name : :obj:`str`
         The model's name.
-    features : :obj:`list` of :obj:`str`
+    features : :obj:`list` [:obj:`str`]
         Names of the model features.
     parameters : :obj:`dict`
         Contains the model's parameters
-    obs_models : Tuple[ObservationModel, ...]
+    obs_models : :obj:`tuple` [:class:`~leaspy.models.obs_models`, ...]
         The observation model(s) associated to the model.
     fit_metrics : :obj:`dict`
         Contains the metrics that are measured during the fit of the model and reported to the user.
-    _state : State
+    _state : :class:`~leaspy.variables.state.State`
         Private instance holding all values for model variables and their derived variables.
     """
 
@@ -85,9 +85,28 @@ class McmcSaemCompatibleModel(StatefulModel):
 
     @property
     def observation_model_names(self) -> list[str]:
+        """Get the names of the observation models.
+
+        Returns
+        -------
+        :obj:`list` [:obj:`str`] :
+            The names of the observation models.
+        """
         return [model.to_string() for model in self.obs_models]
 
     def has_observation_model_with_name(self, name: str) -> bool:
+        """
+        Check if the model has an observation model with the given name.
+        Parameters
+        ----------
+        name : :obj:`str`
+            The name of the observation model to check.
+
+        Returns
+        -------
+        :obj:`bool`:
+            True if the model has an observation model with the given name, False otherwise.
+        """
         return name in self.observation_model_names
 
     def to_dict(self, **kwargs) -> KwargsType:
@@ -95,7 +114,7 @@ class McmcSaemCompatibleModel(StatefulModel):
 
         Returns
         -------
-        KwargsType :
+        :class:`~leaspy.utils.typing.KwargsType`
             The model instance serialized as a dictionary.
         """
         d = super().to_dict()
@@ -116,20 +135,29 @@ class McmcSaemCompatibleModel(StatefulModel):
 
         Parameters
         ----------
-        hyperparameters : :obj:`dict` [ :obj:`str`, Any ]
+        hyperparameters : :obj:`dict` [ :obj:`str`, :obj:`Any` ]
             Contains the model's hyperparameters.
 
-        Raises
-        ------
-        :exc:`.LeaspyModelInputError`
-            If any of the consistency checks fail.
         """
 
     @classmethod
     def _raise_if_unknown_hyperparameters(
         cls, known_hps: Iterable[str], given_hps: KwargsType
     ) -> None:
-        """Raises a :exc:`.LeaspyModelInputError` if any unknown hyperparameter is provided to the model."""
+        """Check if the given hyperparameters are known for the model.
+
+        Parameters
+        ----------
+        known_hps : :obj:`Iterable` [:obj:`str`]
+            The known hyperparameters for the model.
+        given_hps : :class:`~leaspy.utils.typing.KwargsType`
+            The hyperparameters provided to the model.
+
+        Raises
+        ------
+        :exc:`.LeaspyModelInputError`
+            If any unknown hyperparameter is provided to the model.
+        """
         # TODO: replace with better logic from GenericModel in the future
         unexpected_hyperparameters = set(given_hps.keys()).difference(known_hps)
         if len(unexpected_hyperparameters) > 0:
@@ -150,8 +178,8 @@ class McmcSaemCompatibleModel(StatefulModel):
 
         Parameters
         ----------
-        individual_parameters : :obj:`dict` [param: str, Any]
-            Contains some un-trusted individual parameters.
+        individual_parameters : :class:`~leaspy.utils.typing.DictParams`
+            Contains some individual parameters.
             If representing only one individual (in a multivariate model) it could be:
                 * {'tau':0.1, 'xi':-0.3, 'sources':[0.1,...]}
 
@@ -162,7 +190,7 @@ class McmcSaemCompatibleModel(StatefulModel):
 
         Returns
         -------
-        ips_info : :obj:`dict`
+        ips_info : :class:`~leaspy.utils.typing.KwargsType`
             * ``'nb_inds'`` : :obj:`int` >= 0
                 Number of individuals present.
             * ``'tensorized_ips'`` : :obj:`dict` [ :obj:`str`, :class:`torch.Tensor` ]
@@ -170,11 +198,9 @@ class McmcSaemCompatibleModel(StatefulModel):
             * ``'tensorized_ips_gen'`` : generator
                 Generator providing tensorized individual parameters for
                 all individuals present (ordered as is).
-
         Raises
         ------
-        :exc:`.LeaspyIndividualParamsInputError`
-            If any of the consistency/compatibility checks fail.
+        :exc:`.NotImplementedError`
         """
         raise NotImplementedError
 
@@ -185,6 +211,30 @@ class McmcSaemCompatibleModel(StatefulModel):
         *,
         skip_ips_checks: bool = False,
     ) -> tuple[torch.Tensor, DictParamsTorch]:
+        """Convert the timepoints and individual parameters to tensors.
+
+        Parameters
+        ----------
+        timepoints : :obj:`torch.Tensor`
+            Contains the timepoints (age(s) of the subject).
+
+        individual_parameters : :class:`~leaspy.utils.typing.DictParamsTorch`
+            Contains the individual parameters.
+
+        skip_ips_checks : :obj:`bool` (default: ``False``)
+            Flag to skip consistency/compatibility checks and tensorization
+            of ``individual_parameters`` when it was done earlier (speed-up).
+
+        Returns
+        -------
+        :obj:`tuple` [:class:`torch.Tensor`, :class:`~leaspy.utils.typing.DictParamsTorch`]
+            The timepoints and individual parameters converted to tensors.
+
+        Raises
+        ------
+        :exc:`.LeaspyModelInputError`
+            If computation is tried on more than 1 individual.
+        """
         from .utilities import tensorize_2D
 
         if not skip_ips_checks:
@@ -204,7 +254,18 @@ class McmcSaemCompatibleModel(StatefulModel):
     def _check_individual_parameters_provided(
         self, individual_parameters_keys: Iterable[str]
     ) -> None:
-        """Check consistency of individual parameters keys provided."""
+        """Check consistency of individual parameters keys provided.
+
+        Parameters
+        ----------
+        individual_parameters_keys : :obj:`Iterable` [:obj:`str`]
+            The keys of the individual parameters provided.
+
+        Raises
+        ------
+        :exc:`.LeaspyIndividualParamsInputError`
+            If any of the individual parameters keys are unknown or missing.
+        """
         ind_vars = set(self.individual_variables_names)
         unknown_ips = set(individual_parameters_keys).difference(ind_vars)
         missing_ips = ind_vars.difference(individual_parameters_keys)
@@ -230,11 +291,13 @@ class McmcSaemCompatibleModel(StatefulModel):
 
         Parameters
         ----------
-        timepoints : scalar or array_like[scalar] (:obj:`list`, :obj:`tuple`, :class:`numpy.ndarray`)
+        timepoints : :obj:`scalar` or :obj:`array_like` [:obj:`scalar`] (:obj:`list`, :obj:`tuple`, :class:`numpy.ndarray`)
             Contains the age(s) of the subject.
-        individual_parameters : :obj:`dict`
+
+        individual_parameters : :class:`~leaspy.utils.typing.DictParams`
             Contains the individual parameters.
             Each individual parameter should be a scalar or array_like.
+
         skip_ips_checks : :obj:`bool` (default: ``False``)
             Flag to skip consistency/compatibility checks and tensorization
             of ``individual_parameters`` when it was done earlier (speed-up).
@@ -244,13 +307,6 @@ class McmcSaemCompatibleModel(StatefulModel):
         :class:`torch.Tensor`
             Contains the subject's scores computed at the given age(s)
             Shape of tensor is ``(1, n_tpts, n_features)``.
-
-        Raises
-        ------
-        :exc:`.LeaspyModelInputError`
-            If computation is tried on more than 1 individual.
-        :exc:`.LeaspyIndividualParamsInputError`
-            if invalid individual parameters.
         """
         self._check_individual_parameters_provided(individual_parameters.keys())
         timepoints, individual_parameters = self._get_tensorized_inputs(
@@ -280,15 +336,24 @@ class McmcSaemCompatibleModel(StatefulModel):
 
         Parameters
         ----------
-        timepoints : :class:`torch.Tensor` [1, n_timepoints]
-        prior_type : LatentVariableInitType
-        n_individuals : int, optional
+        timepoints : :obj:`torch.Tensor` [1, n_timepoints]
+            Contains the timepoints (age(s) of the subject).
+
+        prior_type : :class:`~leaspy.variables.specs.LatentVariableInitType`
+            The type of prior to use for the individual parameters.
+
+        n_individuals : :obj:`int`, optional
             The number of individuals.
 
         Returns
         -------
         :class:`torch.Tensor` [1, n_timepoints, dimension]
             The group-average values at given timepoints.
+
+        Raises
+        ------
+        :exc:`.LeaspyModelInputError`
+            If `n_individuals` is provided but not a positive integer, or if it is provided while `prior_type` is not `LatentVariableInitType.PRIOR_SAMPLES`.
         """
         exc_n_ind_iff_prior_samples = LeaspyModelInputError(
             "You should provide n_individuals (int >= 1) if, "
@@ -310,15 +375,40 @@ class McmcSaemCompatibleModel(StatefulModel):
 
         return local_state["model"]
 
-    def compute_mean_traj(self, timepoints: torch.Tensor):
-        """Trajectory for average of individual parameters (not really meaningful for non-linear models)."""
+    def compute_mean_traj(
+        self, timepoints: torch.Tensor
+    ) -> TensorOrWeightedTensor[float]:
+        """Trajectory for average of individual parameters (not really meaningful for non-linear models).
+
+        Parameters
+        ----------
+        timepoints : :obj:`torch.Tensor` [1, n_timepoints]
+
+        Returns
+        -------
+        :class:`torch.Tensor` [1, n_timepoints, dimension]
+            The group-average values at given timepoints.
+        """
         # TODO/WIP: keep this in BaseModel interface? or only provide `compute_prior_trajectory`, or `compute_mode|typical_traj` instead?
         return self.compute_prior_trajectory(
             timepoints, LatentVariableInitType.PRIOR_MEAN
         )
 
-    def compute_mode_traj(self, timepoints: torch.Tensor):
-        """Most typical individual trajectory."""
+    def compute_mode_traj(
+        self, timepoints: torch.Tensor
+    ) -> TensorOrWeightedTensor[float]:
+        """Most typical individual trajectory.
+
+        Parameters
+        ----------
+        timepoints : :obj:`torch.Tensor` [1, n_timepoints]
+
+        Returns
+        -------
+        :class:`torch.Tensor` [1, n_timepoints, dimension]
+            The group-average values at given timepoints.
+
+        """
         return self.compute_prior_trajectory(
             timepoints, LatentVariableInitType.PRIOR_MODE
         )
@@ -334,14 +424,17 @@ class McmcSaemCompatibleModel(StatefulModel):
 
         Parameters
         ----------
-        state : :class:`.State`
-            Instance holding values for all model variables (including latent individual variables), as well as:
-            - timepoints : :class:`torch.Tensor` of shape (n_individuals, n_timepoints)
+        state : :class:`~leaspy.variables.state.State`
+            Instance holding values for all model variables (including latent individual variables)
 
         Returns
         -------
-        :obj:`dict` [ param_name: :obj:`str`, :class:`torch.Tensor` ] :
+        :class:`~leaspy.utils.typing.DictParamsTorch`
             Tensors are of shape ``(n_individuals, n_timepoints, n_features, n_dims_param)``.
+
+        Raises
+        ------
+        :exc:`NotImplementedError`
         """
         # return {
         #     ip: state[f"model_jacobian_{ip}"]
@@ -356,11 +449,12 @@ class McmcSaemCompatibleModel(StatefulModel):
 
         Parameters
         ----------
-        state : :class:`.State`
+        state : :class:`~leaspy.variables.state.State`
 
         Returns
         -------
-        :obj:`dict` [ suff_stat: :obj:`str`, :class:`torch.Tensor`]
+        :class:`~leaspy.variables.specs.SuffStatsRW`
+            Contains the sufficient statistics computed from the state.
         """
         suff_stats = {}
         for mp_var in state.dag.sorted_variables_by_type[ModelParameter].values():
@@ -391,9 +485,17 @@ class McmcSaemCompatibleModel(StatefulModel):
 
         Parameters
         ----------
-        state : :class:`.State`
-        sufficient_statistics : dict[suff_stat: str, :class:`torch.Tensor`]
-        burn_in : bool
+        cls : :class:`~leaspy.models.mcmc_saem_compatible.McmcSaemCompatibleModel`
+            Model class to which the parameters belong.
+
+        state : :class:`~leaspy.variables.state.State`
+            Instance holding values for all model variables (including latent individual variables)
+
+        sufficient_statistics : :class:`~leaspy.variables.specs.SuffStatsRO`
+            Contains the sufficient statistics computed from the state.
+
+        burn_in : :obj:`bool`
+            If True, the parameters are updated in a burn-in phase.
         """
         # <!> we should wait before updating state since some updating rules may depending on OLD state
         # (i.e. no sequential update of state but batched updates once all updated values were retrieved)
@@ -411,6 +513,13 @@ class McmcSaemCompatibleModel(StatefulModel):
             state[mp] = mp_updated_val
 
     def get_variables_specs(self) -> NamedVariables:
+        """Get the specifications of the variables used in the model.
+
+        Returns
+        -------
+        :class:`~leaspy.variables.specs.NamedVariables`
+            Specifications of the variables used in the model, including timepoints and observation models.
+        """
         specifications = NamedVariables({"t": DataVariable()})
         single_obs_model = len(self.obs_models) == 1
         for obs_model in self.obs_models:
@@ -421,12 +530,34 @@ class McmcSaemCompatibleModel(StatefulModel):
 
     @abstractmethod
     def put_individual_parameters(self, state: State, dataset: Dataset):
+        """Put the individual parameters inside the provided state (in-place).
+
+        Raises
+        ------
+        :exc:`NotImplementedError`
+
+        """
         raise NotImplementedError()
 
     def _put_data_timepoints(
         self, state: State, timepoints: TensorOrWeightedTensor[float]
     ) -> None:
-        """Put the timepoints variables inside the provided state (in-place)."""
+        """Put the timepoints variables inside the provided state (in-place).
+
+        Parameters
+        ----------
+        state : :class:`~leaspy.variables.state.State`
+            Instance holding values for all model variables (including latent individual variables), as well as:
+            - timepoints : :class:`torch.Tensor` of shape (n_individuals, n_timepoints)
+
+        timepoints : :class:`~leaspy.utils.weighted_tensor.WeightedTensor` or :class:`torch.Tensor`
+            Contains the timepoints (age(s) of the subject).
+
+        Raises
+        ------
+        :exc:`TypeError`
+            If the provided timepoints are not of type :class:`torch.Tensor` or :class:`~leaspy.utils.weighted_tensor.WeightedTensor`.
+        """
         # TODO/WIP: we use a regular tensor with 0 for times so that 'model' is a regular tensor
         # (to avoid having to cope with `StatelessDistributionFamily` having some `WeightedTensor` as parameters)
         if isinstance(timepoints, WeightedTensor):
@@ -440,7 +571,17 @@ class McmcSaemCompatibleModel(StatefulModel):
             )
 
     def put_data_variables(self, state: State, dataset: Dataset) -> None:
-        """Put all the needed data variables inside the provided state (in-place)."""
+        """Put all the needed data variables inside the provided state (in-place).
+
+        Parameters
+        ----------
+
+        state : :class:`~leaspy.variables.state.State`
+            Instance holding values for all model variables (including latent individual variables), as well as:
+            - timepoints : :class:`torch.Tensor` of shape (n_individuals, n_timepoints)
+        dataset : :class:`~leaspy.io.data.dataset.Dataset`
+            The dataset containing the data to be put in the state.
+        """
         self._put_data_timepoints(
             state,
             WeightedTensor(
@@ -451,7 +592,14 @@ class McmcSaemCompatibleModel(StatefulModel):
             state[obs_model.name] = obs_model.getter(dataset)
 
     def reset_data_variables(self, state: State) -> None:
-        """Reset all data variables inside the provided state (in-place)."""
+        """Reset all data variables inside the provided state (in-place).
+
+        Parameters
+        ----------
+        state : :class:`~leaspy.variables.state.State`
+            Instance holding values for all model variables (including latent individual variables), as well as:
+            - timepoints : :class:`torch.Tensor` of shape (n_individuals, n_timepoints)
+        """
         state["t"] = None
         for obs_model in self.obs_models:
             state[obs_model.name] = None

--- a/src/leaspy/models/riemanian_manifold_Schiratti.py
+++ b/src/leaspy/models/riemanian_manifold_Schiratti.py
@@ -1,0 +1,423 @@
+from abc import abstractmethod
+from typing import Iterable, Optional
+
+import pandas as pd
+import torch
+
+from leaspy.io.data.dataset import Dataset
+from leaspy.utils.functional import Exp, OrthoBasis, Sqr
+from leaspy.utils.weighted_tensor import (
+    TensorOrWeightedTensor,
+    WeightedTensor,
+    unsqueeze_right,
+)
+from leaspy.variables.distributions import Normal
+from leaspy.variables.specs import (
+    Hyperparameter,
+    LinkedVariable,
+    ModelParameter,
+    NamedVariables,
+    PopulationLatentVariable,
+    SuffStatsRW,
+    VariableName,
+    VariableNameToValueMapping,
+)
+from leaspy.variables.state import State
+
+from .base import InitializationMethod
+from .obs_models import FullGaussianObservationModel
+from .time_reparametrized_Schiratti import TimeReparametrizedModelSchiratti
+
+# TODO refact? implement a single function
+# compute_individual_tensorized(..., with_jacobian: bool) -> returning either
+# model values or model values + jacobians wrt individual parameters
+
+# TODO refact? subclass or other proper code technique to extract model's concrete
+#  formulation depending on if linear, logistic, mixed log-lin, ...
+
+
+__all__ = [
+    "RiemanianManifoldModelSchiratti",
+    "LinearInitializationMixin",
+    "LinearModel",
+    "LogisticInitializationMixinSchiratti",
+    "LogisticModelSchiratti",
+]
+
+
+class RiemanianManifoldModelSchiratti(TimeReparametrizedModelSchiratti):
+    """Manifold model for multiple variables of interest (logistic or linear formulation).
+
+    Parameters
+    ----------
+    name : :obj:`str`
+        The name of the model.
+    **kwargs
+        Hyperparameters of the model (including `noise_model`)
+
+    Raises
+    ------
+    :exc:`.LeaspyModelInputError`
+        * If hyperparameters are inconsistent
+    """
+
+    def __init__(
+        self,
+        name: str,
+        variables_to_track: Optional[Iterable[VariableName]] = None,
+        **kwargs,
+    ):
+        super().__init__(name, **kwargs)
+        default_variables_to_track = [
+            "g",
+            "v0",
+            "noise_std",
+            "t0_mean",
+            "t0",
+            "tau_std",
+            "xi_mean",
+            "xi_std",
+            "nll_attach",
+            "nll_regul_log_g",
+            "nll_regul_log_v0",
+            "xi",
+            "tau",
+            "nll_regul_pop_sum",
+            "nll_regul_all_sum",
+            "nll_tot",
+        ]
+        if self.source_dimension:
+            default_variables_to_track += [
+                "sources",
+                "betas",
+                "mixing_matrix",
+                "space_shifts",
+            ]
+        self.track_variables(variables_to_track or default_variables_to_track)
+
+    @classmethod
+    def _center_xi_realizations(cls, state: State) -> None:
+        """
+        Center the ``xi`` realizations in place.
+
+        .. note::
+            This operation does not change the orthonormal basis
+            (since the resulting ``v0`` is collinear to the previous one)
+            Nor all model computations (only ``v0 * exp(xi_i)`` matters),
+            it is only intended for model identifiability / ``xi_i`` regularization
+            <!> all operations are performed in "log" space (``v0`` is log'ed)
+
+        Parameters
+        ----------
+        realizations : :class:`.CollectionRealization`
+            The realizations to use for updating the :term:`MCMC` toolbox.
+        """
+        mean_xi = torch.mean(state["xi"])
+        state["xi"] = state["xi"] - mean_xi
+        state["log_v0"] = state["log_v0"] + mean_xi
+
+        # TODO: find a way to prevent re-computation of orthonormal basis since it should
+        #  not have changed (v0_collinear update)
+        # self.update_MCMC_toolbox({'v0_collinear'}, realizations)
+
+    @classmethod
+    def compute_sufficient_statistics(cls, state: State) -> SuffStatsRW:
+        """
+        Compute the model's :term:`sufficient statistics`.
+
+        Parameters
+        ----------
+        state : :class:`.State`
+            The state to pick values from.
+
+        Returns
+        -------
+        SuffStatsRW :
+            The computed sufficient statistics.
+        """
+        # <!> modify 'xi' and 'log_v0' realizations in-place
+        # TODO: what theoretical guarantees for this custom operation?
+        cls._center_xi_realizations(state)
+
+        return super().compute_sufficient_statistics(state)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables, derived variables,
+        model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        NamedVariables :
+            The specifications of the model's variables.
+        """
+        d = super().get_variables_specs()
+        d.update(
+            # PRIORS
+            log_v0_mean=ModelParameter.for_pop_mean(
+                "log_v0",
+                shape=(self.dimension,),
+            ),
+            log_v0_std=Hyperparameter(0.01),
+            xi_mean=Hyperparameter(0.0),
+            # LATENT VARS
+            log_v0=PopulationLatentVariable(
+                Normal("log_v0_mean", "log_v0_std"),
+            ),
+            # DERIVED VARS
+            v0=LinkedVariable(
+                Exp("log_v0"),
+            ),
+            metric=LinkedVariable(
+                self.metric
+            ),  # for linear model: metric & metric_sqr are fixed = 1.
+        )
+        if self.source_dimension >= 1:
+            d.update(
+                model=LinkedVariable(self.model_with_sources),
+                metric_sqr=LinkedVariable(Sqr("metric")),
+                orthonormal_basis=LinkedVariable(OrthoBasis("v0", "metric_sqr")),
+            )
+        else:
+            d["model"] = LinkedVariable(self.model_no_sources)
+
+        # TODO: WIP
+        # variables_info.update(self.get_additional_ordinal_population_random_variable_information())
+        # self.update_ordinal_population_random_variable_information(variables_info)
+
+        return d
+
+    @staticmethod
+    @abstractmethod
+    def metric(*, g: torch.Tensor) -> torch.Tensor:
+        pass
+
+    @classmethod
+    def model_no_sources(cls, *, rt: torch.Tensor, metric, v0, g) -> torch.Tensor:
+        """Returns a model without source. A bit dirty?"""
+        return cls.model_with_sources(
+            rt=rt,
+            metric=metric,
+            v0=v0,
+            g=g,
+            space_shifts=torch.zeros((1, 1)),
+        )
+
+    @classmethod
+    @abstractmethod
+    def model_with_sources(
+        cls,
+        *,
+        rt: torch.Tensor,
+        space_shifts: torch.Tensor,
+        metric,
+        v0,
+        g,
+    ) -> torch.Tensor:
+        pass
+
+
+class LinearInitializationMixin:
+    """Compute initial values for model parameters."""
+
+    def _compute_initial_values_for_model_parameters(
+        self,
+        dataset: Dataset,
+    ) -> VariableNameToValueMapping:
+        from leaspy.models.utilities import (
+            compute_linear_regression_subjects,
+            get_log_velocities,
+            torch_round,
+        )
+
+        df = dataset.to_pandas(apply_headers=True)
+        times = df.index.get_level_values("TIME").values
+        t0 = times.mean()
+
+        d_regress_params = compute_linear_regression_subjects(df, max_inds=None)
+        df_all_regress_params = pd.concat(d_regress_params, names=["feature"])
+        df_all_regress_params["position"] = (
+            df_all_regress_params["intercept"] + t0 * df_all_regress_params["slope"]
+        )
+        df_grp = df_all_regress_params.groupby("feature", sort=False)
+        positions = torch.tensor(df_grp["position"].mean().values)
+        velocities = torch.tensor(df_grp["slope"].mean().values)
+
+        parameters = {
+            "g_mean": positions,
+            "log_v0_mean": get_log_velocities(velocities, self.features),
+            "tau_mean": torch.tensor(t0),
+            "tau_std": self.tau_std,
+            "xi_std": self.xi_std,
+        }
+        if self.source_dimension >= 1:
+            parameters["betas_mean"] = torch.zeros(
+                (self.dimension - 1, self.source_dimension)
+            )
+        rounded_parameters = {
+            str(p): torch_round(v.to(torch.float32)) for p, v in parameters.items()
+        }
+        obs_model = next(iter(self.obs_models))  # WIP: multiple obs models...
+        if isinstance(obs_model, FullGaussianObservationModel):
+            rounded_parameters["noise_std"] = self.noise_std.expand(
+                obs_model.extra_vars["noise_std"].shape
+            )
+        return rounded_parameters
+
+
+class LinearModel(LinearInitializationMixin, RiemanianManifoldModelSchiratti):
+    """Manifold model for multiple variables of interest (linear formulation)."""
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__(name, **kwargs)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables, derived variables,
+        model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        NamedVariables :
+            The specifications of the model's variables.
+        """
+        d = super().get_variables_specs()
+        d.update(
+            g_mean=ModelParameter.for_pop_mean("g", shape=(self.dimension,)),
+            g_std=Hyperparameter(0.01),
+            g=PopulationLatentVariable(Normal("g_mean", "g_std")),
+        )
+
+        return d
+
+    @staticmethod
+    def metric(*, g: torch.Tensor) -> torch.Tensor:
+        """Used to define the corresponding variable."""
+        return torch.ones_like(g)
+
+    @classmethod
+    def model_with_sources(
+        cls,
+        *,
+        rt: torch.Tensor,
+        space_shifts: torch.Tensor,
+        metric,
+        v0,
+        g,
+    ) -> torch.Tensor:
+        """Returns a model with sources."""
+        pop_s = (None, None, ...)
+        rt = unsqueeze_right(rt, ndim=1)  # .filled(float('nan'))
+        return (g[pop_s] + v0[pop_s] * rt + space_shifts[:, None, ...]).weighted_value
+
+
+class LogisticInitializationMixinSchiratti:
+    def _compute_initial_values_for_model_parameters(
+        self,
+        dataset: Dataset,
+    ) -> VariableNameToValueMapping:
+        """Compute initial values for model parameters."""
+        from leaspy.models.utilities import (
+            compute_patient_slopes_distribution,
+            compute_patient_time_distribution,
+            compute_patient_values_distribution,
+            get_log_velocities,
+            torch_round,
+        )
+
+        df = dataset.to_pandas(apply_headers=True)
+        slopes_mu, slopes_sigma = compute_patient_slopes_distribution(df)
+        values_mu, values_sigma = compute_patient_values_distribution(df)
+        time_mu, time_sigma = compute_patient_time_distribution(df)
+
+        if self.initialization_method == InitializationMethod.DEFAULT:
+            slopes = slopes_mu
+            values = values_mu
+            t0 = time_mu
+            betas = torch.zeros((self.dimension - 1, self.source_dimension))
+
+        if self.initialization_method == InitializationMethod.RANDOM:
+            slopes = torch.normal(slopes_mu, slopes_sigma)
+            values = torch.normal(values_mu, values_sigma)
+            t0 = torch.normal(time_mu, time_sigma)
+            betas = torch.distributions.normal.Normal(loc=0.0, scale=1.0).sample(
+                sample_shape=(self.dimension - 1, self.source_dimension)
+            )
+
+        # Enforce values are between 0 and 1
+        values = values.clamp(min=1e-2, max=1 - 1e-2)
+
+        parameters = {
+            "log_g_mean": torch.log(1.0 / values - 1.0),
+            "log_v0_mean": get_log_velocities(slopes, self.features),
+            "t0_mean": t0,
+            "tau_std": self.tau_std,
+            "xi_std": self.xi_std,
+        }
+        if self.source_dimension >= 1:
+            parameters["betas_mean"] = betas
+        rounded_parameters = {
+            str(p): torch_round(v.to(torch.float32)) for p, v in parameters.items()
+        }
+        obs_model = next(iter(self.obs_models))  # WIP: multiple obs models...
+        if isinstance(obs_model, FullGaussianObservationModel):
+            rounded_parameters["noise_std"] = self.noise_std.expand(
+                obs_model.extra_vars["noise_std"].shape
+            )
+        return rounded_parameters
+
+
+class LogisticModelSchiratti(
+    LogisticInitializationMixinSchiratti, RiemanianManifoldModelSchiratti
+):
+    """Manifold model for multiple variables of interest (logistic formulation)."""
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__(name, **kwargs)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables, derived variables,
+        model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        NamedVariables :
+            The specifications of the model's variables.
+        """
+        d = super().get_variables_specs()
+        d.update(
+            log_g_mean=ModelParameter.for_pop_mean("log_g", shape=(self.dimension,)),
+            log_g_std=Hyperparameter(0.01),
+            log_g=PopulationLatentVariable(Normal("log_g_mean", "log_g_std")),
+            g=LinkedVariable(Exp("log_g")),
+        )
+
+        return d
+
+    @staticmethod
+    def metric(*, g: torch.Tensor) -> torch.Tensor:
+        """Used to define the corresponding variable."""
+        return (g + 1) ** 2 / g
+
+    @classmethod
+    def model_with_sources(
+        cls,
+        *,
+        rt: TensorOrWeightedTensor[float],
+        space_shifts: TensorOrWeightedTensor[float],
+        metric: TensorOrWeightedTensor[float],
+        v0: TensorOrWeightedTensor[float],
+        g: TensorOrWeightedTensor[float],
+    ) -> torch.Tensor:
+        """Returns a model with sources."""
+        # Shape: (Ni, Nt, Nfts)
+        pop_s = (None, None, ...)
+        rt = unsqueeze_right(rt, ndim=1)  # .filled(float('nan'))
+        w_model_logit = metric[pop_s] * (
+            v0[pop_s] * rt + space_shifts[:, None, ...]
+        ) - torch.log(g[pop_s])
+        model_logit, weights = WeightedTensor.get_filled_value_and_weight(
+            w_model_logit, fill_value=0.0
+        )
+        return WeightedTensor(torch.sigmoid(model_logit), weights).weighted_value

--- a/src/leaspy/models/time_reparametrized_Schiratti.py
+++ b/src/leaspy/models/time_reparametrized_Schiratti.py
@@ -1,0 +1,569 @@
+import warnings
+from typing import Optional, Union
+
+import torch
+
+from leaspy.exceptions import LeaspyIndividualParamsInputError, LeaspyModelInputError
+from leaspy.io.data.dataset import Dataset
+from leaspy.utils.functional import Exp, MatMul
+from leaspy.utils.typing import DictParams, DictParamsTorch, FeatureType, KwargsType
+from leaspy.utils.weighted_tensor import TensorOrWeightedTensor
+from leaspy.variables.distributions import Normal
+from leaspy.variables.specs import (
+    Hyperparameter,
+    IndividualLatentVariable,
+    LatentVariableInitType,
+    LinkedVariable,
+    ModelParameter,
+    NamedVariables,
+    PopulationLatentVariable,
+)
+from leaspy.variables.state import State
+
+from .mcmc_saem_compatible import McmcSaemCompatibleModel
+from .obs_models import observation_model_factory
+
+__all__ = ["TimeReparametrizedModel"]
+
+
+class TimeReparametrizedModelSchiratti(McmcSaemCompatibleModel):
+    """
+    Contains the common attributes & methods of the multivariate time-reparametrized models.
+
+    Parameters
+    ----------
+    name : :obj:`str`
+        Name of the model.
+    source_dimension : Optional[:obj:`int`]
+        Number of sources. Dimension of spatial components (default is None).
+    **kwargs
+        Hyperparameters for the model (including `obs_models`).
+
+    Raises
+    ------
+    :exc:`.LeaspyModelInputError`
+        If inconsistent hyperparameters.
+    """
+
+    _xi_std = 0.5
+    _tau_std = 5.0
+    _noise_std = 0.1
+    _sources_std = 1.0
+
+    def __init__(
+        self,
+        name: str,
+        source_dimension: Optional[int] = None,
+        **kwargs,
+    ):
+        # TODO / WIP / TMP: dirty for now...
+        # Should we:
+        # - use factory of observation models instead? dataset -> ObservationModel
+        # - or refact a bit `ObservationModel` structure? (lazy init of its variables...)
+        # (cf. note in AbstractModel as well)
+        dimension = kwargs.get("dimension", None)
+        if "features" in kwargs:
+            dimension = len(kwargs["features"])
+        # source_dimension = kwargs.get("source_dimension", None)
+        # if dimension == 1 and source_dimension not in {0, None}:
+        #    raise LeaspyModelInputError(
+        #        "You should not provide `source_dimension` != 0 for univariate model."
+        #    )
+        # self.source_dimension: Optional[int] = source_dimension
+        observation_models = kwargs.get("obs_models", None)
+        if observation_models is None:
+            observation_models = (
+                "gaussian-scalar" if dimension is None else "gaussian-diagonal"
+            )
+        if isinstance(observation_models, (list, tuple)):
+            kwargs["obs_models"] = tuple(
+                [
+                    observation_model_factory(obs_model, **kwargs)
+                    for obs_model in observation_models
+                ]
+            )
+        elif isinstance(observation_models, dict):
+            # Not really satisfied... Used for api load
+            kwargs["obs_models"] = tuple(
+                [
+                    observation_model_factory(
+                        observation_models["y"], dimension=dimension
+                    )
+                ]
+            )
+        else:
+            kwargs["obs_models"] = (
+                observation_model_factory(observation_models, dimension=dimension),
+            )
+        super().__init__(name, **kwargs)
+        self._source_dimension = self._validate_source_dimension(source_dimension)
+
+    @property
+    def xi_std(self) -> torch.Tensor:
+        """Return the standard deviation of xi as a tensor."""
+        return torch.tensor([self._xi_std])
+
+    @property
+    def tau_std(self) -> torch.Tensor:
+        """Return the standard deviation of tau as a tensor."""
+        return torch.tensor([self._tau_std])
+
+    @property
+    def noise_std(self) -> torch.Tensor:
+        """Return the standard deviation of the model as a tensor."""
+        return torch.tensor(self._noise_std)
+
+    @property
+    def sources_std(self) -> float:
+        """Return the standard deviation of sources as a float."""
+        return self._sources_std
+
+    @property
+    def source_dimension(self) -> Optional[int]:
+        """Return the number of the sources"""
+        return self._source_dimension
+
+    @source_dimension.setter
+    def source_dimension(self, source_dimension: Optional[int] = None):
+        """Set the dimensionality of the source space for the model."""
+        self._source_dimension = self._validate_source_dimension(source_dimension)
+
+    def _validate_source_dimension(self, source_dimension: Optional[int] = None) -> int:
+        """
+        Validate and sanitize the `source_dimension` parameter.
+
+        Parameters
+        ----------
+        source_dimension : Optional[:obj:`int`], default=None
+            The candidate source dimension to validate.
+
+        Returns
+        -------
+        Optional[:obj:`int`]
+            The validated source dimension value. Returns 0 if the model dimension is 1,
+            otherwise returns the validated `source_dimension` or None if not provided.
+
+        Raises
+        ------
+         :exc:`.LeaspyModelInputError`
+            If `source_dimension` is not an integer, is negative, or exceeds the allowable range
+            based on the model's dimension.
+        """
+        if self.dimension == 1:
+            return 0
+        if source_dimension is not None:
+            if not isinstance(source_dimension, int):
+                raise LeaspyModelInputError(
+                    f"`source_dimension` must be an integer, not {type(source_dimension)}"
+                )
+            if source_dimension < 0:
+                raise LeaspyModelInputError(
+                    f"`source_dimension` must be >= 0, you provided {source_dimension}"
+                )
+            if self.dimension is not None and source_dimension > self.dimension - 1:
+                raise LeaspyModelInputError(
+                    f"Source dimension should be within [0, {self.dimension - 1}], "
+                    f"you provided {source_dimension}"
+                )
+        return source_dimension
+
+    @property
+    def has_sources(self) -> bool:
+        """
+        Indicates whether the model includes sources.
+
+        Returns
+        -------
+        :obj:`bool`
+            True if `source_dimension` is a positive integer.
+            False otherwise.
+        """
+        return (
+            hasattr(self, "source_dimension")
+            and isinstance(self.source_dimension, int)
+            and self.source_dimension > 0
+        )
+
+    @staticmethod
+    def time_reparametrization(
+        *,
+        t: TensorOrWeightedTensor[float],
+        alpha: torch.Tensor,
+        tau: torch.Tensor,
+        t0: torch.Tensor,
+    ) -> TensorOrWeightedTensor[float]:
+        """
+        Tensorized time reparametrization formula.
+
+        .. warning::
+            Shapes of tensors must be compatible between them.
+
+        Parameters
+        ----------
+        t : :class:`torch.Tensor`
+            Timepoints to reparametrize
+        alpha : :class:`torch.Tensor`
+            Acceleration factors of individual(s)
+        tau : :class:`torch.Tensor`
+            Time-shift(s) of individual(s)
+
+        Returns
+        -------
+        :class:`torch.Tensor`
+            Reparametrized time of same shape as `timepoints`
+        """
+        return alpha * (t - t0 - tau)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables,
+        derived variables, model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        NamedVariables :
+            A dictionary-like object containing specifications for the variables
+        """
+        specifications = super().get_variables_specs()
+        specifications.update(
+            rt=LinkedVariable(self.time_reparametrization),
+            # PRIORS
+            t0_mean=ModelParameter.for_pop_mean("t0", shape=(1,)),
+            t0_std=Hyperparameter(0.1),
+            tau_mean=Hyperparameter(0.0),
+            tau_std=ModelParameter.for_ind_std("tau", shape=(1,)),
+            xi_std=ModelParameter.for_ind_std("xi", shape=(1,)),
+            # LATENT VARS
+            t0=PopulationLatentVariable(Normal("t0_mean", "t0_std")),
+            xi=IndividualLatentVariable(Normal("xi_mean", "xi_std")),
+            tau=IndividualLatentVariable(Normal("tau_mean", "tau_std")),
+            # DERIVED VARS
+            alpha=LinkedVariable(Exp("xi")),
+        )
+        if self.source_dimension >= 1:
+            specifications.update(
+                # PRIORS
+                betas_mean=ModelParameter.for_pop_mean(
+                    "betas",
+                    shape=(self.dimension - 1, self.source_dimension),
+                ),
+                betas_std=Hyperparameter(0.01),
+                sources_mean=Hyperparameter(torch.zeros((self.source_dimension,))),
+                sources_std=Hyperparameter(1.0),
+                # LATENT VARS
+                betas=PopulationLatentVariable(
+                    Normal("betas_mean", "betas_std"),
+                    sampling_kws={"scale": 0.5},  # cf. GibbsSampler (for retro-compat)
+                ),
+                sources=IndividualLatentVariable(Normal("sources_mean", "sources_std")),
+                # DERIVED VARS
+                mixing_matrix=LinkedVariable(
+                    MatMul("orthonormal_basis", "betas").then(torch.t)
+                ),  # shape: (Ns, Nfts)
+                space_shifts=LinkedVariable(
+                    MatMul("sources", "mixing_matrix")
+                ),  # shape: (Ni, Nfts)
+            )
+
+        return specifications
+
+    def _validate_compatibility_of_dataset(
+        self, dataset: Optional[Dataset] = None
+    ) -> None:
+        """
+        Validate the compatibility of the provided dataset with the model's configuration.
+
+        Parameters
+        ----------
+        dataset : Optional[Dataset], optional
+            The dataset to validate against, by default None.
+
+        Raises
+        ------
+        LeaspyModelInputError
+            If `source_dimension` is provided but not an integer in the valid range
+            [0, dataset.dimension - 1).
+        """
+        super()._validate_compatibility_of_dataset(dataset)
+        if not dataset:
+            return
+        if self.source_dimension is None:
+            self.source_dimension = int(dataset.dimension**0.5)
+            warnings.warn(
+                "You did not provide `source_dimension` hyperparameter for multivariate model, "
+                f"setting it to ⌊√dimension⌋ = {self.source_dimension}."
+            )
+        elif not (
+            isinstance(self.source_dimension, int)
+            and 0 <= self.source_dimension < dataset.dimension
+        ):
+            raise LeaspyModelInputError(
+                f"Sources dimension should be an integer in [0, dimension - 1[ "
+                f"but you provided `source_dimension` = {self.source_dimension} "
+                f"whereas `dimension` = {dataset.dimension}."
+            )
+
+    def _audit_individual_parameters(
+        self, individual_parameters: DictParams
+    ) -> KwargsType:
+        """
+        Validate and process individual parameter inputs for model compatibility.
+
+        Parameters
+        ----------
+        individual_parameters : DictParams
+            A dictionary mapping parameter names (strings) to their values,
+            which can be scalars or array-like structures.
+
+        Returns
+        -------
+        KwargsType
+            A dictionary with the following keys:
+            - "nb_inds": Number of individuals
+            - "tensorized_ips": Dictionary of parameters converted to 2D tensors.
+            - "tensorized_ips_gen": Generator yielding tensors for each individual,
+            each with an added batch dimension.
+
+        Raises
+        ------
+        LeaspyIndividualParamsInputError
+            If the provided dictionary keys do not match the expected parameter names,
+            or if the sizes of individual parameters are inconsistent,
+            or if `sources` parameter does not meet array-like requirements.
+        """
+        from .utilities import is_array_like, tensorize_2D
+
+        expected_parameters = set(["xi", "tau"] + int(self.has_sources) * ["sources"])
+        given_parameters = set(individual_parameters.keys())
+        symmetric_diff = expected_parameters.symmetric_difference(given_parameters)
+        if len(symmetric_diff) > 0:
+            raise LeaspyIndividualParamsInputError(
+                f"Individual parameters dict provided {given_parameters} "
+                f"is not compatible for {self.name} model. "
+                f"The expected individual parameters are {expected_parameters}."
+            )
+        ips_is_array_like = {
+            k: is_array_like(v) for k, v in individual_parameters.items()
+        }
+        ips_size = {
+            k: len(v) if ips_is_array_like[k] else 1
+            for k, v in individual_parameters.items()
+        }
+        if self.has_sources:
+            if not ips_is_array_like["sources"]:
+                raise LeaspyIndividualParamsInputError(
+                    f"Sources must be an array_like but {individual_parameters['sources']} was provided."
+                )
+            tau_xi_scalars = all(ips_size[k] == 1 for k in ["tau", "xi"])
+            if tau_xi_scalars and (ips_size["sources"] > 1):
+                # is 'sources' not a nested array? (allowed iff tau & xi are scalars)
+                if not is_array_like(individual_parameters["sources"][0]):
+                    # then update sources size (1D vector representing only 1 individual)
+                    ips_size["sources"] = 1
+            # TODO? check source dimension compatibility?
+        uniq_sizes = set(ips_size.values())
+        if len(uniq_sizes) != 1:
+            raise LeaspyIndividualParamsInputError(
+                f"Individual parameters sizes are not compatible together. Sizes are {ips_size}."
+            )
+        # number of individuals present
+        n_individual_parameters = uniq_sizes.pop()
+        # properly choose unsqueezing dimension when tensorizing array_like (useful for sources)
+        # [1,2] => [[1],[2]] (expected for 2 individuals / 1D sources)
+        # [1,2] => [[1,2]] (expected for 1 individual / 2D sources)
+        unsqueeze_dim = 0 if n_individual_parameters == 1 else -1
+        # tensorized (2D) version of ips
+        tensorized_individual_parameters = {
+            name: tensorize_2D(value, unsqueeze_dim=unsqueeze_dim)
+            for name, value in individual_parameters.items()
+        }
+
+        return {
+            "nb_inds": n_individual_parameters,
+            "tensorized_ips": tensorized_individual_parameters,
+            "tensorized_ips_gen": (
+                {
+                    name: value[individual, :].unsqueeze(0)
+                    for name, value in tensorized_individual_parameters.items()
+                }
+                for individual in range(n_individual_parameters)
+            ),
+        }
+
+    def _load_hyperparameters(self, hyperparameters: KwargsType) -> None:
+        """
+        Updates all model hyperparameters from the provided dictionary.
+
+        Parameters
+        ----------
+        hyperparameters : KwargsType
+            Dictionary containing the hyperparameters to be loaded.
+            Expected keys include:
+            - "features": List or sequence of feature names
+            - "dimension": Integer specifying the number of features
+            - "source_dimension": Integer specifying the number of sources; must be in
+            [0, dimension - 1].
+
+        Raises
+        ------
+        LeaspyModelInputError
+            If `dimension` does not match the length of `features`, or if `source_dimension`
+            is not an integer within the valid range [0, dimension - 1].
+        """
+        if "features" in hyperparameters:
+            self.features = hyperparameters["features"]
+
+        if "dimension" in hyperparameters:
+            if self.features and hyperparameters["dimension"] != len(self.features):
+                raise LeaspyModelInputError(
+                    f"Dimension provided ({hyperparameters['dimension']}) does not match "
+                    f"features ({len(self.features)})"
+                )
+            self.dimension = hyperparameters["dimension"]
+
+        if "source_dimension" in hyperparameters:
+            if not (
+                isinstance(hyperparameters["source_dimension"], int)
+                and (hyperparameters["source_dimension"] >= 0)
+                and (
+                    self.dimension is None
+                    or hyperparameters["source_dimension"] <= self.dimension - 1
+                )
+            ):
+                raise LeaspyModelInputError(
+                    f"Source dimension should be an integer in [0, dimension - 1], "
+                    f"not {hyperparameters['source_dimension']}"
+                )
+            self.source_dimension = hyperparameters["source_dimension"]
+
+    def put_individual_parameters(self, state: State, dataset: Dataset):
+        """
+        Initialize individual latent parameters in the given state if not already set.
+
+        Parameters
+        ----------
+        state : State
+            The current state object that holds all the variables
+        dataset : Dataset
+            Dataset used to initialize latent variables accordingly.
+        """
+        if not state.are_variables_set(("xi", "tau")):
+            with state.auto_fork(None):
+                state.put_individual_latent_variables(
+                    LatentVariableInitType.PRIOR_SAMPLES,
+                    n_individuals=dataset.n_individuals,
+                )
+
+    def to_dict(self, *, with_mixing_matrix: bool = True) -> KwargsType:
+        """
+        Export model object as dictionary ready for :term:`JSON` saving.
+
+        Parameters
+        ----------
+        with_mixing_matrix : :obj:`bool` (default ``True``)
+            Save the :term:`mixing matrix` in the exported file in its 'parameters' section.
+
+            .. warning::
+                It is not a real parameter and its value will be overwritten at model loading
+                (orthonormal basis is recomputed from other "true" parameters and mixing matrix
+                is then deduced from this orthonormal basis and the betas)!
+                It was integrated historically because it is used for convenience in
+                browser webtool and only there...
+
+        Returns
+        -------
+        KwargsType :
+            The object as a dictionary.
+        """
+        model_settings = super().to_dict()
+        model_settings["source_dimension"] = self.source_dimension
+
+        if with_mixing_matrix and self.source_dimension >= 1:
+            # transposed compared to previous version
+            model_settings["parameters"]["mixing_matrix"] = self.state[
+                "mixing_matrix"
+            ].tolist()
+
+        return model_settings
+
+    # TODO: unit tests? (functional tests covered by api.estimate)
+    def compute_individual_ages_from_biomarker_values(
+        self,
+        value: Union[float, list[float]],
+        individual_parameters: DictParams,
+        feature: Optional[FeatureType] = None,
+    ) -> torch.Tensor:
+        """
+        For one individual, compute age(s) at which the given features values
+        are reached (given the subject's individual parameters).
+
+        Consistency checks are done in the main :term:`API` layer.
+
+        Parameters
+        ----------
+        value : scalar or array_like[scalar] (:obj:`list`, :obj:`tuple`, :class:`numpy.ndarray`)
+            Contains the :term:`biomarker` value(s) of the subject.
+
+        individual_parameters : :obj:`dict`
+            Contains the individual parameters.
+            Each individual parameter should be a scalar or array_like.
+
+        feature : :obj:`str` (or None)
+            Name of the considered :term:`biomarker`.
+
+            .. note::
+                Optional for :class:`.UnivariateModel`, compulsory
+                for :class:`.MultivariateModel`.
+
+        Returns
+        -------
+        :class:`torch.Tensor`
+            Contains the subject's ages computed at the given values(s).
+            Shape of tensor is ``(1, n_values)``.
+
+        Raises
+        ------
+        :exc:`.LeaspyModelInputError`
+            If computation is tried on more than 1 individual.
+        """
+        # value, individual_parameters = self._get_tensorized_inputs(
+        #     value, individual_parameters, skip_ips_checks=False
+        # )
+        # return self.compute_individual_ages_from_biomarker_values_tensorized(
+        #     value, individual_parameters, feature
+        # )
+        raise NotImplementedError("This method is currently not implemented.")
+
+    def compute_individual_ages_from_biomarker_values_tensorized(
+        self,
+        value: torch.Tensor,
+        individual_parameters: DictParamsTorch,
+        feature: Optional[FeatureType],
+    ) -> torch.Tensor:
+        """
+        For one individual, compute age(s) at which the given features values are
+        reached (given the subject's individual parameters), with tensorized inputs.
+
+        Parameters
+        ----------
+        value : :class:`torch.Tensor` of shape ``(1, n_values)``
+            Contains the :term:`biomarker` value(s) of the subject.
+
+        individual_parameters : DictParamsTorch
+            Contains the individual parameters.
+            Each individual parameter should be a :class:`torch.Tensor`.
+
+        feature : :obj:`str` (or None)
+            Name of the considered :term:`biomarker`.
+
+            .. note::
+                Optional for :class:`.UnivariateModel`, compulsory
+                for :class:`.MultivariateModel`.
+
+        Returns
+        -------
+        :class:`torch.Tensor`
+            Contains the subject's ages computed at the given values(s).
+            Shape of tensor is ``(n_values, 1)``.
+        """
+        raise NotImplementedError("This method is currently not implemented.")

--- a/src/leaspy/samplers/gibbs.py
+++ b/src/leaspy/samplers/gibbs.py
@@ -309,6 +309,11 @@ class AbstractPopulationGibbsSampler(GibbsSamplerMixin, AbstractPopulationSample
         for idx in self._get_shuffled_iterator_indices():
             previous_attachment, previous_regularity = compute_attachment_regularity()
             # with state.auto_fork():  # not needed since state already have auto_fork on
+
+            # if self.name in ["phi_g", "log_g"]:
+            #     print(f"\n[POP DEBUG] Sampling {self.name}, idx={idx}")
+            #     print(f"  prev_attach mean={float(previous_attachment.mean()):.4f}, " f"prev_regul mean={float(previous_regularity.mean()):.4f}")
+
             state.put(
                 self.name,
                 self._proposed_change_idx(idx),
@@ -325,8 +330,20 @@ class AbstractPopulationGibbsSampler(GibbsSamplerMixin, AbstractPopulationSample
                     + (new_attachment - previous_attachment)
                 )
             )
+
+            # if self.name in ["phi_g", "log_g"]:
+            #     print(f"  new_attach mean={float(new_attachment.mean()):.4f}, "
+            #         f"new_regul mean={float(new_regularity.mean()):.4f}")
+            #     print(f"  Δattach={float((new_attachment - previous_attachment).mean()):.4f}, "
+            #         f"Δregul={float((new_regularity - previous_regularity).mean()):.4f}, "
+            #         f"α mean={float(alpha.mean()):.4f}, "
+            #         f"min={float(alpha.min()):.4f}, max={float(alpha.max()):.4f}")
+
             accepted = self._metropolis_step(alpha)
             accepted_array[idx] = accepted
+
+            # if self.name in ["phi_g", "log_g"]:
+            #     print(f"  accepted: {bool(accepted)}")
 
             if not accepted:
                 state.revert()

--- a/src/leaspy/samplers/gibbs.py
+++ b/src/leaspy/samplers/gibbs.py
@@ -719,6 +719,20 @@ class IndividualGibbsSampler(GibbsSamplerMixin, AbstractIndividualSampler):
             )
 
         previous_attachment, previous_regularity = compute_attachment_regularity()
+
+        # print("variable:", self.name)
+
+        # if self.name == "phi_tau":
+        #     # shapes & quick stats
+        #     print("[DEBUG] phi_tau: current shape", tuple(state["phi_tau"].shape))
+        #     print("[DEBUG] prev_attach shape", tuple(previous_attachment.shape), " prev_attach mean", float(previous_attachment.mean()))
+        #     print("[DEBUG] prev_regul shape", tuple(previous_regularity.shape), " prev_regul mean", float(previous_regularity.mean()))
+        # if self.name == "tau":
+        #     # shapes & quick stats
+        #     print("[DEBUG] tau: current shape", tuple(state["tau"].shape))
+        #     print("[DEBUG] prev_attach shape", tuple(previous_attachment.shape), " prev_attach mean", float(previous_attachment.mean()))
+        #     print("[DEBUG] prev_regul shape", tuple(previous_regularity.shape), " prev_regul mean", float(previous_regularity.mean()))
+
         # with state.auto_fork():
         state.put(
             self.name,
@@ -736,7 +750,20 @@ class IndividualGibbsSampler(GibbsSamplerMixin, AbstractIndividualSampler):
                 + (new_attachment - previous_attachment)
             )
         )
+
+        # if self.name == "phi_tau":
+        #     print("[DBG] alpha: shape", tuple(alpha.shape),
+        #         " mean", float(alpha.mean()), " min", float(alpha.min()), " max", float(alpha.max()))
+        #     # detect NaN/Inf
+        #     print("[DBG] alpha has_nan", bool(torch.isnan(alpha).any()), " has_inf", bool(torch.isinf(alpha).any()))
+
         accepted = self._group_metropolis_step(alpha)
+
+        # if self.name == "phi_tau":
+        #     print("[DBG] accepted mean (fraction accepted)", float(accepted.float().mean()))
+        #     # show a sample of per-individual alpha/accepted
+        #     print("[DBG] alpha[:10]", alpha[:10].detach().cpu().numpy())
+        #     print("[DBG] accepted[:10]", accepted[:10].detach().cpu().numpy())
 
         # Partial reversion where proposals were not accepted
         state.revert(~accepted)

--- a/src/leaspy/samplers/gibbs.py
+++ b/src/leaspy/samplers/gibbs.py
@@ -720,8 +720,6 @@ class IndividualGibbsSampler(GibbsSamplerMixin, AbstractIndividualSampler):
 
         previous_attachment, previous_regularity = compute_attachment_regularity()
 
-        # print("variable:", self.name)
-
         # if self.name == "phi_tau":
         #     # shapes & quick stats
         #     print("[DEBUG] phi_tau: current shape", tuple(state["phi_tau"].shape))

--- a/src/leaspy/utils/functional/__init__.py
+++ b/src/leaspy/utils/functional/__init__.py
@@ -1,29 +1,39 @@
 from ._functions import (
+    AffineFromVector,
+    BatchMatMulByIndex,
     Exp,
     Identity,
+    IndexOf,
     MatMul,
     Mean,
     OrthoBasis,
+    OrthoBasisBatch,
     Prod,
     Sqr,
     Std,
     Sum,
     SumDim,
+    Unique,
 )
 from ._named_input_function import NamedInputFunction
 from ._utils import get_named_parameters
 
 __all__ = [
+    "AffineFromVector",
+    "BatchMatMulByIndex",
     "Exp",
     "get_named_parameters",
     "Identity",
+    "IndexOf",
     "MatMul",
     "Mean",
     "NamedInputFunction",
     "OrthoBasis",
+    "OrthoBasisBatch",
     "Prod",
     "Sqr",
     "Std",
     "Sum",
     "SumDim",
+    "Unique",
 ]

--- a/src/leaspy/utils/functional/__init__.py
+++ b/src/leaspy/utils/functional/__init__.py
@@ -1,6 +1,8 @@
 from ._functions import (
     AffineFromVector,
     BatchMatMulByIndex,
+    CorrCoeff,
+    Cov,
     Exp,
     Identity,
     IndexOf,
@@ -21,6 +23,8 @@ from ._utils import get_named_parameters
 __all__ = [
     "AffineFromVector",
     "BatchMatMulByIndex",
+    "Cov",
+    "CorrCoeff",
     "Exp",
     "get_named_parameters",
     "Identity",

--- a/src/leaspy/utils/functional/_functions.py
+++ b/src/leaspy/utils/functional/_functions.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import torch
 
-from ..linalg import compute_orthonormal_basis
+from ..linalg import compute_orthonormal_basis, compute_orthonormal_basis_batch
 from ..weighted_tensor import factory_weighted_tensor_unary_operator, sum_dim
 from ._named_input_function import NamedInputFunction
-from ._utils import _arguments_checker, _identity, _prod_args, _sum_args
+from ._utils import _affine_from_vector, _arguments_checker, _batch_matmul_by_index, _identity, _index_of, _prod_args, _sum_args, _unique_wrapper
 
 __all__ = [
     "Prod",
@@ -20,6 +20,10 @@ __all__ = [
     "Std",
     "SumDim",
     "Sum",
+    "AffineFromVector",
+    "Unique",
+    "IndexOf",
+    "batch_matmul_by_index",
 ]
 
 
@@ -49,8 +53,26 @@ MatMul = NamedInputFunction.bound_to(
 )
 
 
+BatchMatMulByIndex = NamedInputFunction.bound_to(
+    _batch_matmul_by_index,
+    _arguments_checker(
+        nb_arguments=3,
+        possible_kws=set()
+    ),
+)
+
+
 OrthoBasis = NamedInputFunction.bound_to(
     compute_orthonormal_basis,
+    _arguments_checker(
+        nb_arguments=2,
+        possible_kws=set("strip_col"),
+    ),
+)
+
+
+OrthoBasisBatch = NamedInputFunction.bound_to(
+    compute_orthonormal_basis_batch,
     _arguments_checker(
         nb_arguments=2,
         possible_kws=set("strip_col"),
@@ -109,6 +131,31 @@ Sum = NamedInputFunction.bound_to(
     _arguments_checker(
         possible_kws={"start"},
     ),
+)
+
+
+AffineFromVector = NamedInputFunction.bound_to(
+    _affine_from_vector,
+    _arguments_checker(
+        nb_arguments=2,
+        possible_kws=set(),
+    ),
+)
+
+Unique = NamedInputFunction.bound_to(
+    _unique_wrapper,
+    _arguments_checker(
+        nb_arguments=1,
+        possible_kws=set(),
+    ),
+)
+
+IndexOf = NamedInputFunction.bound_to(
+    _index_of,
+    _arguments_checker(
+        nb_arguments=2,
+        possible_kws=set()
+    )
 )
 
 

--- a/src/leaspy/utils/functional/_functions.py
+++ b/src/leaspy/utils/functional/_functions.py
@@ -7,7 +7,18 @@ import torch
 from ..linalg import compute_orthonormal_basis, compute_orthonormal_basis_batch
 from ..weighted_tensor import factory_weighted_tensor_unary_operator, sum_dim
 from ._named_input_function import NamedInputFunction
-from ._utils import _affine_from_vector, _arguments_checker, _batch_matmul_by_index, _identity, _index_of, _prod_args, _sum_args, _unique_wrapper
+from ._utils import (
+    _affine_from_vector,
+    _arguments_checker,
+    _batch_matmul_by_index,
+    _corr_coeff,
+    _cov,
+    _identity,
+    _index_of,
+    _prod_args,
+    _sum_args,
+    _unique_wrapper,
+)
 
 __all__ = [
     "Prod",
@@ -23,7 +34,9 @@ __all__ = [
     "AffineFromVector",
     "Unique",
     "IndexOf",
-    "batch_matmul_by_index",
+    "BatchMathMulByIndex",
+    "CorrCoeff",
+    "Cov",
 ]
 
 
@@ -55,10 +68,7 @@ MatMul = NamedInputFunction.bound_to(
 
 BatchMatMulByIndex = NamedInputFunction.bound_to(
     _batch_matmul_by_index,
-    _arguments_checker(
-        nb_arguments=3,
-        possible_kws=set()
-    ),
+    _arguments_checker(nb_arguments=3, possible_kws=set()),
 )
 
 
@@ -151,11 +161,23 @@ Unique = NamedInputFunction.bound_to(
 )
 
 IndexOf = NamedInputFunction.bound_to(
-    _index_of,
+    _index_of, _arguments_checker(nb_arguments=2, possible_kws=set())
+)
+
+CorrCoeff = NamedInputFunction.bound_to(
+    _corr_coeff,
     _arguments_checker(
         nb_arguments=2,
-        possible_kws=set()
-    )
+        possible_kws=set(),
+    ),
+)
+
+Cov = NamedInputFunction.bound_to(
+    _cov,
+    _arguments_checker(
+        nb_arguments=2,
+        possible_kws=set(),
+    ),
 )
 
 

--- a/src/leaspy/utils/functional/_utils.py
+++ b/src/leaspy/utils/functional/_utils.py
@@ -70,7 +70,7 @@ def _corr_coeff(
     std: torch.Tensor,
 ) -> torch.Tensor:
     rho = cov / (std[0] * std[1])
-    # rho = torch.clamp(rho, -0.9999, 0.9999)
+    rho = torch.clamp(rho, -0.9999, 0.9999)
     return rho
 
 

--- a/src/leaspy/utils/functional/_utils.py
+++ b/src/leaspy/utils/functional/_utils.py
@@ -65,6 +65,24 @@ def _unique_wrapper(x) -> torch.Tensor:
     return torch.unique(x)
 
 
+def _corr_coeff(
+    cov: torch.Tensor,
+    std: torch.Tensor,
+) -> torch.Tensor:
+    rho = cov / (std[0] * std[1])
+    # rho = torch.clamp(rho, -0.9999, 0.9999)
+    return rho
+
+
+def _cov(
+    rho: torch.Tensor,
+    std: torch.Tensor,
+) -> torch.Tensor:
+    rho = torch.clamp(rho, -0.9999, 0.9999)
+    cov = rho * std[0] * std[1]
+    return cov
+
+
 def _index_of(
     covariates: torch.Tensor,
     unique_covariates: torch.Tensor,

--- a/src/leaspy/utils/linalg.py
+++ b/src/leaspy/utils/linalg.py
@@ -4,6 +4,7 @@ from leaspy.exceptions import LeaspyModelInputError
 
 __all__ = [
     "compute_orthonormal_basis",
+    "compute_orthonormal_basis_batch",
 ]
 
 
@@ -118,3 +119,19 @@ def compute_orthonormal_basis(
 
     # concat columns (get rid of the one collinear to `dgamma_t0`)
     return torch.cat((q_matrix[:, :strip_col], q_matrix[:, strip_col + 1 :]), dim=1)
+
+
+def compute_orthonormal_basis_batch(
+    dgamma_t0: torch.Tensor, G_metric: torch.Tensor, *, strip_col: int = 0
+) -> torch.Tensor:
+    """
+    Applique compute_orthonormal_basis individuellement à chaque (dgamma_t0[i], G_metric[i]).
+    """
+    bases = []
+    for i in range(dgamma_t0.shape[1]):
+        basis_i = compute_orthonormal_basis(
+            dgamma_t0[:, i], G_metric[:, i], strip_col=strip_col
+        )
+        bases.append(basis_i)
+    return torch.stack(bases)  # -> shape (N, D, D-1)
+

--- a/src/leaspy/variables/distributions.py
+++ b/src/leaspy/variables/distributions.py
@@ -393,6 +393,9 @@ class BivariateNormalFamily(StatelessDistributionFamilyFromTorchDistribution):
         Returns a bivariate normal distribution with given means, stds, and correlation.
         Assumes shape broadcasting is consistent.
         """
+        print("loc.requires_grad:", loc.requires_grad)
+        print("scale.requires_grad:", scale.requires_grad)
+        print("coeff_corr.requires_grad:", coeff_corr.requires_grad)
 
         if loc.dim() == 1:
             loc = loc.unsqueeze(0)
@@ -426,15 +429,10 @@ class BivariateNormalFamily(StatelessDistributionFamilyFromTorchDistribution):
     def sample(
         cls, *params: torch.Tensor, sample_shape: tuple[int, ...] = ()
     ) -> torch.Tensor:
-        loc, scale, rho = params
-
-        Ni = sample_shape[0]
-        loc = loc.unsqueeze(0).expand(Ni, -1)  # (Ni, 2)
-        scale = scale.unsqueeze(0).expand(Ni, -1)  # (Ni, 2)
-        rho = rho.expand(Ni)  # (Ni,)
-
-        dist = cls.dist_factory(loc, scale, rho)
-        sample = dist.sample()
+        dist = cls.dist_factory(*params)
+        sample = dist.rsample(sample_shape)
+        sample = sample.squeeze(1) if sample.dim() == 3 else sample
+        print("sample shape:", sample.shape)
         return sample
 
     @classmethod

--- a/src/leaspy/variables/distributions.py
+++ b/src/leaspy/variables/distributions.py
@@ -452,9 +452,7 @@ class BivariateNormalFamily(StatelessDistributionFamilyFromTorchDistribution):
             dim=-2,
         )  # shape (..., 2, 2)
 
-        mean = loc
-
-        dist = cls.dist_factory(mean, cov)
+        dist = cls.dist_factory(loc, cov)
         sample = dist.sample(sample_shape)
         sample = sample.squeeze(1) if sample.dim() == 3 else sample
         print("sample shape:", sample.shape)

--- a/src/leaspy/variables/distributions.py
+++ b/src/leaspy/variables/distributions.py
@@ -699,12 +699,18 @@ class BivariateNormalFamilyPop(StatelessDistributionFamilyFromTorchDistribution)
         values: WeightedTensor,
         loc: torch.Tensor,
         scale: torch.Tensor,
-        coeff_corr: torch.Tensor,
+        cov: torch.Tensor,
     ) -> WeightedTensor:
+        loc = loc.expand_as(values.value)
+        scale = scale.expand_as(values.value)
+        cov = cov.expand(values.value.shape[0])
+
         x, y = values.value.unbind(-1)
         x_mu, y_mu = loc.unbind(-1)
         x_std, y_std = scale.unbind(-1)
-        rho = coeff_corr
+
+        rho = cov / (x_std * y_std)
+        rho = torch.clamp(rho, -0.9999, 0.9999)
 
         norm_x = (x - x_mu) / x_std
         norm_y = (y - y_mu) / y_std
@@ -801,23 +807,23 @@ class BivariateNormalFamilyInd(StatelessDistributionFamilyFromTorchDistribution)
     def sample(
         cls, *params: torch.Tensor, sample_shape: tuple[int, ...] = ()
     ) -> torch.Tensor:
-        loc, scale, coeff_corr = params
+        loc, scale, cov = params
 
         if loc.dim() == 1:
             loc = loc.unsqueeze(0)
         if scale.dim() == 1:
             scale = scale.unsqueeze(0)
-        if coeff_corr.dim() == 0:
-            coeff_corr = coeff_corr.unsqueeze(0)
+        if cov.dim() == 0:
+            cov = cov.unsqueeze(0)
 
         # Covariance matrix
         x_std, y_std = scale.unbind(-1)
-        rho = coeff_corr
+        # rho = cov / (x_std*y_std)
 
         eps = 1e-6
         cov_11 = x_std**2 + eps
         cov_22 = y_std**2 + eps
-        cov_12 = rho * x_std * y_std
+        cov_12 = cov
 
         cov = torch.stack(
             [
@@ -911,18 +917,18 @@ class BivariateNormalFamilyInd(StatelessDistributionFamilyFromTorchDistribution)
         values: WeightedTensor,
         loc: torch.Tensor,
         scale: torch.Tensor,
-        coeff_corr: torch.Tensor,
+        cov: torch.Tensor,
     ) -> WeightedTensor:
         x, y = values.value.unbind(-1)
         x_mu, y_mu = loc[None, :].expand(x.shape[0], -1).unbind(-1)
         x_std, y_std = scale[None, :].expand(x.shape[0], -1).unbind(-1)
-        rho = coeff_corr
-        if rho.ndim == 0:
-            rho = rho.expand(values.value.shape[0])
+        if cov.ndim == 0:
+            cov = cov.expand(values.value.shape[0])
 
         # numeric safety: clamp std and rho
         x_std = x_std.clamp(min=1e-8)
         y_std = y_std.clamp(min=1e-8)
+        rho = cov / (x_std * y_std)
         rho = rho.clamp(min=-0.9999, max=0.9999)
 
         norm_x = (x - x_mu) / x_std

--- a/src/leaspy/variables/specs.py
+++ b/src/leaspy/variables/specs.py
@@ -217,7 +217,7 @@ class ModelParameter(IndepVariable):
     suff_stats: Collect  # Callable[[VariablesValuesRO], SuffStatsRW]
     """
     The symbolic update functions will take variadic `suff_stats` values,
-    in order to re-use NamedInputFunction logic: e.g. update_rule=Std('xi')
+    in order to reuse NamedInputFunction logic: e.g. update_rule=Std('xi')
 
     <!> ISSUE: for `tau_std` and `xi_std` we also need `state` values in addition to
     `suff_stats` values (only after burn-in) since we can NOT use the variadic form
@@ -392,7 +392,7 @@ class ModelParameter(IndepVariable):
         shape: tuple[int, ...],
     ):
         """Smart automatic definition of `ModelParameter` when it is a correlation coefficient (rho)
-        between two components of an individual latent variable (e.g. phi_tau[:, 0] and phi_tau[:, 1]).
+        between two components of an population latent variable (e.g. phi_tau[:, 0] and phi_tau[:, 1]).
         """
         update_rule = NamedInputFunction(
             compute_correlation_pop,
@@ -642,7 +642,7 @@ class LinkedVariable(VariableInterface):
         :class:`~leaspy.variables.specs.VariableValue` :
             The value of the variable.
         """
-        # print({k: state[k].shape for k in self.parameters})
+        # print("[debug]", {k: state[k].shape for k in self.parameters})
         return self.f(**{k: state[k] for k in self.parameters})
 
 

--- a/src/leaspy/variables/specs.py
+++ b/src/leaspy/variables/specs.py
@@ -43,6 +43,8 @@ from .distributions import SymbolicDistribution
 from .utilities import (
     compute_correlation_ind,
     compute_correlation_pop,
+    compute_cov_ind,
+    compute_cov_pop,
     compute_individual_parameter_std_from_sufficient_statistics,
 )
 
@@ -392,7 +394,7 @@ class ModelParameter(IndepVariable):
         shape: tuple[int, ...],
     ):
         """Smart automatic definition of `ModelParameter` when it is a correlation coefficient (rho)
-        between two components of an population latent variable (e.g. phi_tau[:, 0] and phi_tau[:, 1]).
+        between two components of an population latent variable.
         """
         update_rule = NamedInputFunction(
             compute_correlation_pop,
@@ -410,6 +412,67 @@ class ModelParameter(IndepVariable):
             suff_stats=Collect(variable_name),
             update_rule=update_rule,
         )
+
+    @classmethod
+    def for_ind_cov(
+        cls,
+        variable_name: VariableName,
+        shape: tuple[int, ...],
+    ):
+        """Smart automatic definition of `ModelParameter` when it is a correlation coefficient (rho)
+        between two components of an individual latent variable (e.g. phi_tau[:, 0] and phi_tau[:, 1]).
+        """
+        update_rule = NamedInputFunction(
+            compute_cov_ind,
+            parameters=(
+                "state",
+                variable_name,
+            ),
+            kws=dict(
+                parameters_name=variable_name,
+                dim=LVL_IND,
+            ),
+        )
+        return cls(
+            shape,
+            suff_stats=Collect(variable_name),
+            update_rule=update_rule,
+        )
+
+    @classmethod
+    def for_pop_cov(
+        cls,
+        variable_name: VariableName,
+        shape: tuple[int, ...],
+    ):
+        update_rule = NamedInputFunction(
+            compute_cov_pop,
+            parameters=(
+                "state",
+                variable_name,
+            ),
+            kws=dict(
+                parameters_name=variable_name,
+                dim=LVL_IND,
+            ),
+        )
+        return cls(
+            shape,
+            suff_stats=Collect(variable_name),
+            update_rule=update_rule,
+        )
+
+    # @classmethod
+    # def for_pop_cov(
+    #     cls,
+    #     variable_name: VariableName,
+    #     shape: tuple[int, ...],
+    # ):
+    #     return cls(
+    #         shape,
+    #         suff_stats=None,
+    #         update_rule=Identity(variable_name),
+    #     )
 
 
 @dataclass(frozen=True)

--- a/src/leaspy/variables/state.py
+++ b/src/leaspy/variables/state.py
@@ -225,6 +225,7 @@ class State(MutableMapping):
         if not force_computation:
             if (value := self._values[name]) is not None:
                 return value
+        # print(f"\n [DAG] Computing variable: {name}")
         value = self.dag[name].compute(self._values)
         if value is None:
             raise LeaspyInputError(
@@ -509,6 +510,8 @@ class State(MutableMapping):
                     f"{variable_name}_{i}": value[:, i].tolist()
                     for i in range(value.shape[1])
                 }
+        elif value.ndim == 3:
+            return {variable_name: value.tolist()}
         else:
             raise ValueError(
                 f"The value of variable {variable_name} "

--- a/src/leaspy/variables/state.py
+++ b/src/leaspy/variables/state.py
@@ -225,7 +225,7 @@ class State(MutableMapping):
         if not force_computation:
             if (value := self._values[name]) is not None:
                 return value
-        # print(f"\n [DAG] Computing variable: {name}")
+        # print(f"\n [DEBUG] [DAG] Computing variable: {name}")
         value = self.dag[name].compute(self._values)
         if value is None:
             raise LeaspyInputError(

--- a/src/leaspy/variables/utilities.py
+++ b/src/leaspy/variables/utilities.py
@@ -114,5 +114,6 @@ def compute_correlation_pop(
         raise ValueError(f"Standard deviation is zero for parameter {parameters_name}")
 
     rho = covariance / (std_mod * std_ref)  # shape: (K,)
+    rho = torch.clamp(rho, -0.9999, 0.9999)
 
     return rho  # shape: (K,)

--- a/src/leaspy/variables/utilities.py
+++ b/src/leaspy/variables/utilities.py
@@ -114,7 +114,5 @@ def compute_correlation_pop(
         raise ValueError(f"Standard deviation is zero for parameter {parameters_name}")
 
     rho = covariance / (std_mod * std_ref)  # shape: (K,)
-    # print("[DEBUG] rho", rho)
-    # print(f"[DEBUG] rho_{parameters_name} update:", rho.tolist(), flush=True)
 
     return rho  # shape: (K,)

--- a/src/leaspy/variables/utilities.py
+++ b/src/leaspy/variables/utilities.py
@@ -76,7 +76,8 @@ def compute_correlation_ind(
         raise ValueError(f"Standard deviation is zero for parameter {parameters_name}")
 
     rho = covariance / (std_mod * std_ref)
-    print(parameters_name, "update:", rho.item(), flush=True)
+    print("rho", rho)
+    print(f"rho_{parameters_name} update:", rho.item(), flush=True)
 
     return rho  # shape: (1,)
 
@@ -112,7 +113,8 @@ def compute_correlation_pop(
         raise ValueError(f"Standard deviation is zero for parameter {parameters_name}")
 
     rho = covariance / (std_mod * std_ref)  # shape: (K,)
-    print(parameters_name, "update:", rho.tolist(), flush=True)
+    print("rho", rho)
+    print(f"rho_{parameters_name} update:", rho.tolist(), flush=True)
 
     return rho  # shape: (K,)
 

--- a/src/leaspy/variables/utilities.py
+++ b/src/leaspy/variables/utilities.py
@@ -76,8 +76,9 @@ def compute_correlation_ind(
         raise ValueError(f"Standard deviation is zero for parameter {parameters_name}")
 
     rho = covariance / (std_mod * std_ref)
-    print("rho", rho)
-    print(f"rho_{parameters_name} update:", rho.item(), flush=True)
+    rho = torch.clamp(rho, -0.9999, 0.9999)
+    # print("[DEBUG] rho", rho)
+    # print(f"[DEBUG] rho_{parameters_name} update:", rho.item(), flush=True)
 
     return rho  # shape: (1,)
 
@@ -113,8 +114,7 @@ def compute_correlation_pop(
         raise ValueError(f"Standard deviation is zero for parameter {parameters_name}")
 
     rho = covariance / (std_mod * std_ref)  # shape: (K,)
-    print("rho", rho)
-    print(f"rho_{parameters_name} update:", rho.tolist(), flush=True)
+    # print("[DEBUG] rho", rho)
+    # print(f"[DEBUG] rho_{parameters_name} update:", rho.tolist(), flush=True)
 
     return rho  # shape: (K,)
-

--- a/src/leaspy/variables/utilities.py
+++ b/src/leaspy/variables/utilities.py
@@ -2,6 +2,8 @@ import torch
 
 __all__ = [
     "compute_individual_parameter_std_from_sufficient_statistics",
+    "compute_correlation_ind",
+    "compute_correlation_pop",
 ]
 
 
@@ -43,3 +45,74 @@ def compute_individual_parameter_std_from_sufficient_statistics(
     return compute_std_from_variance(
         individual_parameter_variance, varname=f"{individual_parameter_name}_std", **kws
     )
+
+
+def compute_correlation_ind(
+    state: dict[str, torch.Tensor],
+    parameters_values: torch.Tensor,
+    *,
+    parameters_name: str,
+    dim: int,
+):
+    parameters_mean = state[f"{parameters_name}_mean"]  # shape: (2,)
+    parameters_std = state[f"{parameters_name}_std"]  # shape: (2,)
+
+    if parameters_mean.ndim != 1 or parameters_mean.shape[0] != 2:
+        raise ValueError(
+            f"Expected mean shape (2,) for individual parameter {parameters_name}"
+        )
+
+    phi_mod_mean, phi_ref_mean = parameters_mean
+    phi_mod = parameters_values[:, 0]
+    phi_ref = parameters_values[:, 1]
+
+    phi_mod_centered = phi_mod - phi_mod_mean
+    phi_ref_centered = phi_ref - phi_ref_mean
+
+    covariance = torch.mean(phi_mod_centered * phi_ref_centered)
+
+    std_mod, std_ref = parameters_std
+    if std_mod == 0 or std_ref == 0:
+        raise ValueError(f"Standard deviation is zero for parameter {parameters_name}")
+
+    rho = covariance / (std_mod * std_ref)
+    print(parameters_name, "update:", rho.item(), flush=True)
+
+    return rho  # shape: (1,)
+
+
+def compute_correlation_pop(
+    state: dict[str, torch.Tensor],
+    parameters_values: torch.Tensor,
+    *,
+    parameters_name: str,
+    dim: int,
+):
+    parameters_mean = state[f"{parameters_name}_mean"]  # shape: (K, 2)
+    parameters_std = state[f"{parameters_name}_std"]  # shape: (2,)
+
+    if parameters_mean.ndim != 2 or parameters_mean.shape[1] != 2:
+        raise ValueError(
+            f"Expected mean shape (K, 2) for population parameter {parameters_name}"
+        )
+
+    phi_mod_mean = parameters_mean[:, 0]  # shape: (K,)
+    phi_ref_mean = parameters_mean[:, 1]  # shape: (K,)
+
+    phi_mod = parameters_values[:, 0]  # shape: (K,)
+    phi_ref = parameters_values[:, 1]  # shape: (K,)
+
+    phi_mod_centered = phi_mod - phi_mod_mean
+    phi_ref_centered = phi_ref - phi_ref_mean
+
+    covariance = phi_mod_centered * phi_ref_centered  # shape: (K,)
+
+    std_mod, std_ref = parameters_std
+    if torch.any(std_mod == 0) or torch.any(std_ref == 0):
+        raise ValueError(f"Standard deviation is zero for parameter {parameters_name}")
+
+    rho = covariance / (std_mod * std_ref)  # shape: (K,)
+    print(parameters_name, "update:", rho.tolist(), flush=True)
+
+    return rho  # shape: (K,)
+

--- a/src/leaspy/variables/utilities.py
+++ b/src/leaspy/variables/utilities.py
@@ -4,6 +4,7 @@ __all__ = [
     "compute_individual_parameter_std_from_sufficient_statistics",
     "compute_correlation_ind",
     "compute_correlation_pop",
+    "compute_cov_pop",
 ]
 
 
@@ -54,8 +55,8 @@ def compute_correlation_ind(
     parameters_name: str,
     dim: int,
 ):
-    parameters_mean = state[f"{parameters_name}_mean"]  # shape: (2,)
-    parameters_std = state[f"{parameters_name}_std"]  # shape: (2,)
+    parameters_mean = state[f"{parameters_name}_mean"]
+    parameters_std = state[f"{parameters_name}_std"]
 
     if parameters_mean.ndim != 1 or parameters_mean.shape[0] != 2:
         raise ValueError(
@@ -77,8 +78,6 @@ def compute_correlation_ind(
 
     rho = covariance / (std_mod * std_ref)
     rho = torch.clamp(rho, -0.9999, 0.9999)
-    # print("[DEBUG] rho", rho)
-    # print(f"[DEBUG] rho_{parameters_name} update:", rho.item(), flush=True)
 
     return rho  # shape: (1,)
 
@@ -108,6 +107,80 @@ def compute_correlation_pop(
     phi_ref_centered = phi_ref - phi_ref_mean
 
     covariance = phi_mod_centered * phi_ref_centered  # shape: (K,)
+
+    std_mod, std_ref = parameters_std
+    if torch.any(std_mod == 0) or torch.any(std_ref == 0):
+        raise ValueError(f"Standard deviation is zero for parameter {parameters_name}")
+
+    rho = covariance / (std_mod * std_ref)  # shape: (K,)
+    rho = torch.clamp(rho, -0.9999, 0.9999)
+
+    return rho  # shape: (K,)
+
+
+def compute_cov_ind(
+    state: dict[str, torch.Tensor],
+    parameters_values: torch.Tensor,
+    *,
+    parameters_name: str,
+    dim: int,
+):
+    parameters_mean = state[f"{parameters_name}_mean"]
+    parameters_std = state[f"{parameters_name}_std"]
+
+    if parameters_mean.ndim != 1 or parameters_mean.shape[0] != 2:
+        raise ValueError(
+            f"Expected mean shape (2,) for individual parameter {parameters_name}"
+        )
+
+    phi_mod_mean, phi_ref_mean = parameters_mean
+    phi_mod = parameters_values[:, 0]
+    phi_ref = parameters_values[:, 1]
+
+    phi_mod_centered = phi_mod - phi_mod_mean
+    phi_ref_centered = phi_ref - phi_ref_mean
+
+    covariance = torch.mean(phi_mod_centered * phi_ref_centered)
+
+    return covariance
+
+    std_mod, std_ref = parameters_std
+    if std_mod == 0 or std_ref == 0:
+        raise ValueError(f"Standard deviation is zero for parameter {parameters_name}")
+
+    rho = covariance / (std_mod * std_ref)
+    rho = torch.clamp(rho, -0.9999, 0.9999)
+
+    return rho
+
+
+def compute_cov_pop(
+    state: dict[str, torch.Tensor],
+    parameters_values: torch.Tensor,
+    *,
+    parameters_name: str,
+    dim: int,
+):
+    parameters_mean = state[f"{parameters_name}_mean"]  # shape: (K, 2)
+    parameters_std = state[f"{parameters_name}_std"]  # shape: (2,)
+
+    if parameters_mean.ndim != 2 or parameters_mean.shape[1] != 2:
+        raise ValueError(
+            f"Expected mean shape (K, 2) for population parameter {parameters_name}"
+        )
+
+    phi_mod_mean = parameters_mean[:, 0]  # shape: (K,)
+    phi_ref_mean = parameters_mean[:, 1]  # shape: (K,)
+
+    phi_mod = parameters_values[:, 0]  # shape: (K,)
+    phi_ref = parameters_values[:, 1]  # shape: (K,)
+
+    phi_mod_centered = phi_mod - phi_mod_mean
+    phi_ref_centered = phi_ref - phi_ref_mean
+
+    covariance = phi_mod_centered * phi_ref_centered  # shape: (K,)
+
+    return covariance
 
     std_mod, std_ref = parameters_std
     if torch.any(std_mod == 0) or torch.any(std_ref == 0):


### PR DESCRIPTION
### Add Covariate Model Structure

This PR introduces the full implementation of the covariate model, following the standard architecture:

- `CovariateTimeReparametrizedModel` inherits from `McmcSaemCompatibleModel`  
- `CovariateRiemanianManifoldModel` inherits from `CovariateTimeReparametrizedModel`  
- `CovariateLogisticModel` inherits from:
  - `CovariateLogisticInitializationMixin`
  - `CovariateRiemanianManifoldModel`

---

###  Notes

- The model **runs**, and the population parameters `g` and `v0` are properly updated during the iterations.
-  **Known issue**: the `tau` parameters **are not updated** during training yet. This behavior needs further investigation.
