### PR TITLE
separate logistic and linear

### DIFF
--- a/src/leaspy/models/__init__.py
+++ b/src/leaspy/models/__init__.py
@@ -2,13 +2,11 @@ from .base import BaseModel, ModelInterface
 from .constant import ConstantModel
 from .factory import ModelName, model_factory
 from .joint import JointModel
+from .linear import LinearModel
 from .lme import LMEModel
+from .logistic import LogisticModel
 from .mcmc_saem_compatible import McmcSaemCompatibleModel
-from .riemanian_manifold import (
-    LinearModel,
-    LogisticModel,
-    RiemanianManifoldModel,
-)
+from .riemanian_manifold import RiemanianManifoldModel
 from .settings import ModelSettings
 from .shared_speed_logistic import SharedSpeedLogisticModel
 from .stateful import StatefulModel

--- a/src/leaspy/models/factory.py
+++ b/src/leaspy/models/factory.py
@@ -4,8 +4,9 @@ from typing import Optional, Union
 from .base import BaseModel
 from .constant import ConstantModel
 from .joint import JointModel
+from .linear import LinearModel
 from .lme import LMEModel
-from .riemanian_manifold import LinearModel, LogisticModel
+from .logistic import LogisticModel
 from .shared_speed_logistic import SharedSpeedLogisticModel
 
 __all__ = [

--- a/src/leaspy/models/joint.py
+++ b/src/leaspy/models/joint.py
@@ -21,8 +21,8 @@ from leaspy.variables.specs import (
 )
 from leaspy.variables.state import State
 
+from .logistic import LogisticModel
 from .obs_models import observation_model_factory
-from .riemanian_manifold import LogisticModel
 
 __all__ = ["JointModel"]
 

--- a/src/leaspy/models/linear.py
+++ b/src/leaspy/models/linear.py
@@ -1,0 +1,176 @@
+import pandas as pd
+import torch
+
+from leaspy.io.data.dataset import Dataset
+from leaspy.utils.functional import Exp, OrthoBasis, Sqr
+from leaspy.utils.weighted_tensor import (
+    unsqueeze_right,
+)
+from leaspy.variables.distributions import Normal
+from leaspy.variables.specs import (
+    Hyperparameter,
+    ModelParameter,
+    NamedVariables,
+    PopulationLatentVariable,
+    VariableNameToValueMapping,
+)
+
+from .obs_models import FullGaussianObservationModel
+from .riemanian_manifold import RiemanianManifoldModel
+
+__all__ = [
+    "LinearInitializationMixin",
+    "LinearModel",
+]
+
+
+class LinearInitializationMixin:
+    """Compute initial values for model parameters."""
+
+    def _compute_initial_values_for_model_parameters(
+        self,
+        dataset: Dataset,
+    ) -> VariableNameToValueMapping:
+        """
+        Compute and return initial values for the model parameters using linear regression.
+
+        Parameters
+        ----------
+        dataset : :class:`Dataset`
+            The dataset from which to extract observations and masks.
+
+        Returns
+        -------
+        :class:`~leaspy.variables.specs.VariableNameToValueMapping`
+            A dictionary mapping parameter names (as strings) to their initialized
+            torch.Tensor values.
+
+        Notes
+        -----
+        - The initial positions are computed using `intercept + t0 * slope` where `t0`
+        is the mean of all observation times.
+        - Velocities are averaged per feature, and log-transformed using
+        `get_log_velocities`.
+        - Time parameters (`tau_mean`, `tau_std`) and variability parameters
+        (`xi_std`) are also initialized.
+        - If `self.source_dimension >= 1`, zero initialization is used for `betas_mean`.
+        - If the observation model is a `FullGaussianObservationModel`, the
+        `noise_std` parameter is also added, expanded to the correct shape.
+        """
+        from leaspy.models.utilities import (
+            compute_linear_regression_subjects,
+            get_log_velocities,
+            torch_round,
+        )
+
+        df = dataset.to_pandas(apply_headers=True)
+        times = df.index.get_level_values("TIME").values
+        t0 = times.mean()
+
+        d_regress_params = compute_linear_regression_subjects(df, max_inds=None)
+        df_all_regress_params = pd.concat(d_regress_params, names=["feature"])
+        df_all_regress_params["position"] = (
+            df_all_regress_params["intercept"] + t0 * df_all_regress_params["slope"]
+        )
+        df_grp = df_all_regress_params.groupby("feature", sort=False)
+        positions = torch.tensor(df_grp["position"].mean().values)
+        velocities = torch.tensor(df_grp["slope"].mean().values)
+
+        parameters = {
+            "g_mean": positions,
+            "log_v0_mean": get_log_velocities(velocities, self.features),
+            "tau_mean": torch.tensor(t0),
+            "tau_std": self.tau_std,
+            "xi_std": self.xi_std,
+        }
+        if self.source_dimension >= 1:
+            parameters["betas_mean"] = torch.zeros(
+                (self.dimension - 1, self.source_dimension)
+            )
+        rounded_parameters = {
+            str(p): torch_round(v.to(torch.float32)) for p, v in parameters.items()
+        }
+        obs_model = next(iter(self.obs_models))  # WIP: multiple obs models...
+        if isinstance(obs_model, FullGaussianObservationModel):
+            rounded_parameters["noise_std"] = self.noise_std.expand(
+                obs_model.extra_vars["noise_std"].shape
+            )
+        return rounded_parameters
+
+
+class LinearModel(LinearInitializationMixin, RiemanianManifoldModel):
+    """Manifold model for multiple variables of interest (linear formulation)."""
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__(name, **kwargs)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables, derived variables,
+        model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        :class:`~leaspy.variables.specs.NamedVariables :
+            A dictionary-like object mapping variable names to their specifications.
+        """
+        d = super().get_variables_specs()
+        d.update(
+            g_mean=ModelParameter.for_pop_mean("g", shape=(self.dimension,)),
+            g_std=Hyperparameter(0.01),
+            g=PopulationLatentVariable(Normal("g_mean", "g_std")),
+        )
+
+        return d
+
+    @staticmethod
+    def metric(*, g: torch.Tensor) -> torch.Tensor:
+        """
+        Compute the metric tensor for the model.
+
+        Parameters
+        ----------
+        g :  :class:`torch.Tensor`
+            Input tensor with values of the population parameter `g` for each feature.
+
+        Returns
+        -------
+         :class:`torch.Tensor`
+            A tensor of ones with the same shape as `g`.
+        """
+        return torch.ones_like(g)
+
+    @classmethod
+    def model_with_sources(
+        cls,
+        *,
+        rt: torch.Tensor,
+        space_shifts: torch.Tensor,
+        metric,
+        v0,
+        g,
+    ) -> torch.Tensor:
+        """
+        Return the model output when sources(spatial components) are present.
+
+        Parameters
+        ----------
+        rt :  :class:`torch.Tensor`
+            The reparametrized time.
+        space_shifts :  :class:`torch.Tensor`
+            The values of the space-shifts
+        metric : Any
+            The metric tensor used for computing the spatial/temporal influence.
+        v0 : Any
+            The values of the population parameter `v0` for each feature.
+        g : Any
+            The values of the population parameter `g` for each feature.
+
+        Returns
+        -------
+         :class:`torch.Tensor`
+            The model output with contribution from sources.
+        """
+        pop_s = (None, None, ...)
+        rt = unsqueeze_right(rt, ndim=1)  # .filled(float('nan'))
+        return (g[pop_s] + v0[pop_s] * rt + space_shifts[:, None, ...]).weighted_value

--- a/src/leaspy/models/logistic.py
+++ b/src/leaspy/models/logistic.py
@@ -1,0 +1,195 @@
+import torch
+
+from leaspy.io.data.dataset import Dataset
+from leaspy.utils.functional import Exp
+from leaspy.utils.weighted_tensor import (
+    TensorOrWeightedTensor,
+    WeightedTensor,
+    unsqueeze_right,
+)
+from leaspy.variables.distributions import Normal
+from leaspy.variables.specs import (
+    Hyperparameter,
+    LinkedVariable,
+    ModelParameter,
+    NamedVariables,
+    PopulationLatentVariable,
+    VariableNameToValueMapping,
+)
+
+from .base import InitializationMethod
+from .obs_models import FullGaussianObservationModel
+from .riemanian_manifold import RiemanianManifoldModel
+
+__all__ = [
+    "LogisticInitializationMixin",
+    "LogisticModel",
+]
+
+
+class LogisticInitializationMixin:
+    def _compute_initial_values_for_model_parameters(
+        self,
+        dataset: Dataset,
+    ) -> VariableNameToValueMapping:
+        """
+        Compute initial values for model parameters.
+
+        Parameters
+        ----------
+        dataset : :class:`Dataset`
+            The dataset from which to extract observations and masks.
+
+        Returns
+        -------
+        :class:`~leaspy.variables.specs.VariableNameToValueMapping
+            A dictionary mapping parameter names (as strings) to their initialized
+            torch.Tensor values.
+
+        Notes
+        -----
+        - If the initialization method is `DEFAULT`, patient means are used.
+        - If `RANDOM`, parameters are sampled from normal distributions
+        centered at patient means with estimated standard deviations.
+        - `values` are clamped between 0.01 and 0.99 to avoid boundary issues.
+        - If the model includes sources (source_dimension >= 1),
+        regression coefficients `betas_mean` are initialized accordingly.
+        - If the observation model is a `FullGaussianObservationModel`,
+        the noise standard deviation parameter is expanded to the correct shape.
+        """
+        from leaspy.models.utilities import (
+            compute_patient_slopes_distribution,
+            compute_patient_time_distribution,
+            compute_patient_values_distribution,
+            get_log_velocities,
+            torch_round,
+        )
+
+        df = dataset.to_pandas(apply_headers=True)
+        slopes_mu, slopes_sigma = compute_patient_slopes_distribution(df)
+        values_mu, values_sigma = compute_patient_values_distribution(df)
+        time_mu, time_sigma = compute_patient_time_distribution(df)
+
+        if self.initialization_method == InitializationMethod.DEFAULT:
+            slopes = slopes_mu
+            values = values_mu
+            t0 = time_mu
+            betas = torch.zeros((self.dimension - 1, self.source_dimension))
+
+        if self.initialization_method == InitializationMethod.RANDOM:
+            slopes = torch.normal(slopes_mu, slopes_sigma)
+            values = torch.normal(values_mu, values_sigma)
+            t0 = torch.normal(time_mu, time_sigma)
+            betas = torch.distributions.normal.Normal(loc=0.0, scale=1.0).sample(
+                sample_shape=(self.dimension - 1, self.source_dimension)
+            )
+
+        # Enforce values are between 0 and 1
+        values = values.clamp(min=1e-2, max=1 - 1e-2)
+
+        parameters = {
+            "log_g_mean": torch.log(1.0 / values - 1.0),
+            "log_v0_mean": get_log_velocities(slopes, self.features),
+            "tau_mean": t0,
+            "tau_std": self.tau_std,
+            "xi_std": self.xi_std,
+        }
+        if self.source_dimension >= 1:
+            parameters["betas_mean"] = betas
+        rounded_parameters = {
+            str(p): torch_round(v.to(torch.float32)) for p, v in parameters.items()
+        }
+        obs_model = next(iter(self.obs_models))  # WIP: multiple obs models...
+        if isinstance(obs_model, FullGaussianObservationModel):
+            rounded_parameters["noise_std"] = self.noise_std.expand(
+                obs_model.extra_vars["noise_std"].shape
+            )
+        return rounded_parameters
+
+
+class LogisticModel(LogisticInitializationMixin, RiemanianManifoldModel):
+    """Manifold model for multiple variables of interest (logistic formulation)."""
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__(name, **kwargs)
+
+    def get_variables_specs(self) -> NamedVariables:
+        """
+        Return the specifications of the variables (latent variables, derived variables,
+        model 'parameters') that are part of the model.
+
+        Returns
+        -------
+        NamedVariables :
+            A dictionary-like object mapping variable names to their specifications.
+        """
+        d = super().get_variables_specs()
+        d.update(
+            log_g_mean=ModelParameter.for_pop_mean("log_g", shape=(self.dimension,)),
+            log_g_std=Hyperparameter(0.01),
+            log_g=PopulationLatentVariable(Normal("log_g_mean", "log_g_std")),
+            g=LinkedVariable(Exp("log_g")),
+        )
+
+        return d
+
+    @staticmethod
+    def metric(*, g: torch.Tensor) -> torch.Tensor:
+        r"""
+        Compute the metric tensor from input tensor `g`.
+        This function calculates the metric as \((g + 1)^2 / g\) element-wise.
+
+        Parameters
+        ----------
+        g : t :class:`torch.Tensor`
+            Input tensor with values of the population parameter `g` for each feature.
+
+        Returns
+        -------
+         :class:`torch.Tensor`
+            The computed metric tensor, same shape as g(number of features)
+        """
+        return (g + 1) ** 2 / g
+
+    @classmethod
+    def model_with_sources(
+        cls,
+        *,
+        rt: TensorOrWeightedTensor[float],
+        space_shifts: TensorOrWeightedTensor[float],
+        metric: TensorOrWeightedTensor[float],
+        v0: TensorOrWeightedTensor[float],
+        g: TensorOrWeightedTensor[float],
+    ) -> torch.Tensor:
+        """
+        Return the model output when sources(spatial components) are present.
+
+        Parameters
+        ----------
+        rt : TensorOrWeightedTensor[float]
+            Tensor containing the reparametrized time.
+        space_shifts : TensorOrWeightedTensor[float]
+            Tensor containing the values of the space-shifts
+        metric : TensorOrWeightedTensor[float]
+            Tensor containing the metric tensor used for computing the spatial/temporal influence.
+        v0 : TensorOrWeightedTensor[float]
+            Tensor containing the values of the population parameter `v0` for each feature.
+        g : TensorOrWeightedTensor[float]
+            Tensor containing the values of the population parameter `g` for each feature.
+
+        Returns
+        -------
+         :class:`torch.Tensor`
+            Weighted value tensor after applying sigmoid transformation,
+            representing the model output with sources.
+        """
+        # Shape: (Ni, Nt, Nfts)
+        pop_s = (None, None, ...)
+        rt = unsqueeze_right(rt, ndim=1)  # .filled(float('nan'))
+        w_model_logit = metric[pop_s] * (
+            v0[pop_s] * rt + space_shifts[:, None, ...]
+        ) - torch.log(g[pop_s])
+        model_logit, weights = WeightedTensor.get_filled_value_and_weight(
+            w_model_logit, fill_value=0.0
+        )
+        return WeightedTensor(torch.sigmoid(model_logit), weights).weighted_value

--- a/src/leaspy/models/riemanian_manifold.py
+++ b/src/leaspy/models/riemanian_manifold.py
@@ -1,16 +1,9 @@
 from abc import abstractmethod
 from typing import Iterable, Optional
 
-import pandas as pd
 import torch
 
-from leaspy.io.data.dataset import Dataset
 from leaspy.utils.functional import Exp, OrthoBasis, Sqr
-from leaspy.utils.weighted_tensor import (
-    TensorOrWeightedTensor,
-    WeightedTensor,
-    unsqueeze_right,
-)
 from leaspy.variables.distributions import Normal
 from leaspy.variables.specs import (
     Hyperparameter,
@@ -20,12 +13,9 @@ from leaspy.variables.specs import (
     PopulationLatentVariable,
     SuffStatsRW,
     VariableName,
-    VariableNameToValueMapping,
 )
 from leaspy.variables.state import State
 
-from .base import InitializationMethod
-from .obs_models import FullGaussianObservationModel
 from .time_reparametrized import TimeReparametrizedModel
 
 # TODO refact? implement a single function
@@ -40,8 +30,6 @@ __all__ = [
     "RiemanianManifoldModel",
     "LinearInitializationMixin",
     "LinearModel",
-    "LogisticInitializationMixin",
-    "LogisticModel",
 ]
 
 
@@ -98,7 +86,7 @@ class RiemanianManifoldModel(TimeReparametrizedModel):
     def _center_xi_realizations(cls, state: State) -> None:
         """
         Center the ``xi`` realizations in place.
-        
+
         Parameters
         ----------
         state : :class:`.State`
@@ -206,7 +194,7 @@ class RiemanianManifoldModel(TimeReparametrizedModel):
         metric : Any
             The metric tensor used for computing the spatial/temporal influence.
         v0 : Any
-            The values of the popoulation parameter `v0` for each feature.
+            The values of the population parameter `v0` for each feature.
         g : Any
             The values of the population parameter `g` for each feature.
 
@@ -240,323 +228,3 @@ class RiemanianManifoldModel(TimeReparametrizedModel):
         g,
     ) -> torch.Tensor:
         pass
-
-
-class LinearInitializationMixin:
-    """Compute initial values for model parameters."""
-
-    def _compute_initial_values_for_model_parameters(
-        self,
-        dataset: Dataset,
-    ) -> VariableNameToValueMapping:
-        """
-        Compute and return initial values for the model parameters using linear regression.
-        
-        Parameters
-        ----------
-        dataset : :class:`Dataset`
-            The dataset from which to extract observations and masks.
-
-        Returns
-        -------
-        :class:`~leaspy.variables.specs.VariableNameToValueMapping`
-            A dictionary mapping parameter names (as strings) to their initialized
-            torch.Tensor values.
-
-        Notes
-        -----
-        - The initial positions are computed using `intercept + t0 * slope` where `t0`
-        is the mean of all observation times.
-        - Velocities are averaged per feature, and log-transformed using
-        `get_log_velocities`.
-        - Time parameters (`tau_mean`, `tau_std`) and variability parameters
-        (`xi_std`) are also initialized.
-        - If `self.source_dimension >= 1`, zero initialization is used for `betas_mean`.
-        - If the observation model is a `FullGaussianObservationModel`, the
-        `noise_std` parameter is also added, expanded to the correct shape.
-        """
-        from leaspy.models.utilities import (
-            compute_linear_regression_subjects,
-            get_log_velocities,
-            torch_round,
-        )
-
-        df = dataset.to_pandas(apply_headers=True)
-        times = df.index.get_level_values("TIME").values
-        t0 = times.mean()
-
-        d_regress_params = compute_linear_regression_subjects(df, max_inds=None)
-        df_all_regress_params = pd.concat(d_regress_params, names=["feature"])
-        df_all_regress_params["position"] = (
-            df_all_regress_params["intercept"] + t0 * df_all_regress_params["slope"]
-        )
-        df_grp = df_all_regress_params.groupby("feature", sort=False)
-        positions = torch.tensor(df_grp["position"].mean().values)
-        velocities = torch.tensor(df_grp["slope"].mean().values)
-
-        parameters = {
-            "g_mean": positions,
-            "log_v0_mean": get_log_velocities(velocities, self.features),
-            "tau_mean": torch.tensor(t0),
-            "tau_std": self.tau_std,
-            "xi_std": self.xi_std,
-        }
-        if self.source_dimension >= 1:
-            parameters["betas_mean"] = torch.zeros(
-                (self.dimension - 1, self.source_dimension)
-            )
-        rounded_parameters = {
-            str(p): torch_round(v.to(torch.float32)) for p, v in parameters.items()
-        }
-        obs_model = next(iter(self.obs_models))  # WIP: multiple obs models...
-        if isinstance(obs_model, FullGaussianObservationModel):
-            rounded_parameters["noise_std"] = self.noise_std.expand(
-                obs_model.extra_vars["noise_std"].shape
-            )
-        return rounded_parameters
-
-
-class LinearModel(LinearInitializationMixin, RiemanianManifoldModel):
-    """Manifold model for multiple variables of interest (linear formulation)."""
-
-    def __init__(self, name: str, **kwargs):
-        super().__init__(name, **kwargs)
-
-    def get_variables_specs(self) -> NamedVariables:
-        """
-        Return the specifications of the variables (latent variables, derived variables,
-        model 'parameters') that are part of the model.
-
-        Returns
-        -------
-        :class:`~leaspy.variables.specs.NamedVariables :
-            A dictionary-like object mapping variable names to their specifications.
-        """
-        d = super().get_variables_specs()
-        d.update(
-            g_mean=ModelParameter.for_pop_mean("g", shape=(self.dimension,)),
-            g_std=Hyperparameter(0.01),
-            g=PopulationLatentVariable(Normal("g_mean", "g_std")),
-        )
-
-        return d
-
-    @staticmethod
-    def metric(*, g: torch.Tensor) -> torch.Tensor:
-        """
-        Compute the metric tensor for the model.
-    
-        Parameters
-        ----------
-        g :  :class:`torch.Tensor`
-            Input tensor with values of the population parameter `g` for each feature.
-
-        Returns
-        -------
-         :class:`torch.Tensor`
-            A tensor of ones with the same shape as `g`.
-        """
-        return torch.ones_like(g)
-
-    @classmethod
-    def model_with_sources(
-        cls,
-        *,
-        rt: torch.Tensor,
-        space_shifts: torch.Tensor,
-        metric,
-        v0,
-        g,
-    ) -> torch.Tensor:
-        """
-        Return the model output when sources(spatial components) are present.
-
-        Parameters
-        ----------
-        rt :  :class:`torch.Tensor`
-            The reparametrized time.
-        space_shifts :  :class:`torch.Tensor`
-            The values of the space-shifts
-        metric : Any
-            The metric tensor used for computing the spatial/temporal influence.
-        v0 : Any
-            The values of the popoulation parameter `v0` for each feature.
-        g : Any
-            The values of the population parameter `g` for each feature.
-
-        Returns
-        -------
-         :class:`torch.Tensor`
-            The model output with contribution from sources.
-        """
-        pop_s = (None, None, ...)
-        rt = unsqueeze_right(rt, ndim=1)  # .filled(float('nan'))
-        return (g[pop_s] + v0[pop_s] * rt + space_shifts[:, None, ...]).weighted_value
-
-
-class LogisticInitializationMixin:
-    def _compute_initial_values_for_model_parameters(
-        self,
-        dataset: Dataset,
-    ) -> VariableNameToValueMapping:
-        """
-        Compute initial values for model parameters.
-
-        Parameters
-        ----------
-        dataset : :class:`Dataset`
-            The dataset from which to extract observations and masks.
-
-        Returns
-        -------
-        :class:`~leaspy.variables.specs.VariableNameToValueMapping
-            A dictionary mapping parameter names (as strings) to their initialized
-            torch.Tensor values.
-
-        Notes
-        -----
-        - If the initialization method is `DEFAULT`, patient means are used.
-        - If `RANDOM`, parameters are sampled from normal distributions
-        centered at patient means with estimated standard deviations.
-        - `values` are clamped between 0.01 and 0.99 to avoid boundary issues.
-        - If the model includes sources (source_dimension >= 1),
-        regression coefficients `betas_mean` are initialized accordingly.
-        - If the observation model is a `FullGaussianObservationModel`,
-        the noise standard deviation parameter is expanded to the correct shape.
-        """
-        from leaspy.models.utilities import (
-            compute_patient_slopes_distribution,
-            compute_patient_time_distribution,
-            compute_patient_values_distribution,
-            get_log_velocities,
-            torch_round,
-        )
-
-        df = dataset.to_pandas(apply_headers=True)
-        slopes_mu, slopes_sigma = compute_patient_slopes_distribution(df)
-        values_mu, values_sigma = compute_patient_values_distribution(df)
-        time_mu, time_sigma = compute_patient_time_distribution(df)
-
-        if self.initialization_method == InitializationMethod.DEFAULT:
-            slopes = slopes_mu
-            values = values_mu
-            t0 = time_mu
-            betas = torch.zeros((self.dimension - 1, self.source_dimension))
-
-        if self.initialization_method == InitializationMethod.RANDOM:
-            slopes = torch.normal(slopes_mu, slopes_sigma)
-            values = torch.normal(values_mu, values_sigma)
-            t0 = torch.normal(time_mu, time_sigma)
-            betas = torch.distributions.normal.Normal(loc=0.0, scale=1.0).sample(
-                sample_shape=(self.dimension - 1, self.source_dimension)
-            )
-
-        # Enforce values are between 0 and 1
-        values = values.clamp(min=1e-2, max=1 - 1e-2)
-
-        parameters = {
-            "log_g_mean": torch.log(1.0 / values - 1.0),
-            "log_v0_mean": get_log_velocities(slopes, self.features),
-            "tau_mean": t0,
-            "tau_std": self.tau_std,
-            "xi_std": self.xi_std,
-        }
-        if self.source_dimension >= 1:
-            parameters["betas_mean"] = betas
-        rounded_parameters = {
-            str(p): torch_round(v.to(torch.float32)) for p, v in parameters.items()
-        }
-        obs_model = next(iter(self.obs_models))  # WIP: multiple obs models...
-        if isinstance(obs_model, FullGaussianObservationModel):
-            rounded_parameters["noise_std"] = self.noise_std.expand(
-                obs_model.extra_vars["noise_std"].shape
-            )
-        return rounded_parameters
-
-
-class LogisticModel(LogisticInitializationMixin, RiemanianManifoldModel):
-    """Manifold model for multiple variables of interest (logistic formulation)."""
-
-    def __init__(self, name: str, **kwargs):
-        super().__init__(name, **kwargs)
-
-    def get_variables_specs(self) -> NamedVariables:
-        """
-        Return the specifications of the variables (latent variables, derived variables,
-        model 'parameters') that are part of the model.
-
-        Returns
-        -------
-        NamedVariables :
-            A dictionary-like object mapping variable names to their specifications.
-        """
-        d = super().get_variables_specs()
-        d.update(
-            log_g_mean=ModelParameter.for_pop_mean("log_g", shape=(self.dimension,)),
-            log_g_std=Hyperparameter(0.01),
-            log_g=PopulationLatentVariable(Normal("log_g_mean", "log_g_std")),
-            g=LinkedVariable(Exp("log_g")),
-        )
-
-        return d
-
-    @staticmethod
-    def metric(*, g: torch.Tensor) -> torch.Tensor:
-        """
-        Compute the metric tensor from input tensor `g`.
-        This function calculates the metric as \((g + 1)^2 / g\) element-wise.
-
-        Parameters
-        ----------
-        g : t :class:`torch.Tensor`
-            Input tensor with values of the population parameter `g` for each feature.
-
-        Returns
-        -------
-         :class:`torch.Tensor`
-            The computed metric tensor, same shape as g(number of features)
-        """
-        return (g + 1) ** 2 / g
-
-    @classmethod
-    def model_with_sources(
-        cls,
-        *,
-        rt: TensorOrWeightedTensor[float],
-        space_shifts: TensorOrWeightedTensor[float],
-        metric: TensorOrWeightedTensor[float],
-        v0: TensorOrWeightedTensor[float],
-        g: TensorOrWeightedTensor[float],
-    ) -> torch.Tensor:
-        """
-        Return the model output when sources(spatial components) are present.
-
-        Parameters
-        ----------
-        rt : TensorOrWeightedTensor[float]
-            Tensor containing the reparametrized time.
-        space_shifts : TensorOrWeightedTensor[float]
-            Tensor containing the values of the space-shifts
-        metric : TensorOrWeightedTensor[float]
-            Tensor containing the metric tensor used for computing the spatial/temporal influence.
-        v0 : TensorOrWeightedTensor[float]
-            Tensor containing the values of the popoulation parameter `v0` for each feature.
-        g : TensorOrWeightedTensor[float]
-            Tensor containing the values of the population parameter `g` for each feature.
-
-        Returns
-        -------
-         :class:`torch.Tensor`
-            Weighted value tensor after applying sigmoid transformation,
-            representing the model output with sources.
-        """
-        # Shape: (Ni, Nt, Nfts)
-        pop_s = (None, None, ...)
-        rt = unsqueeze_right(rt, ndim=1)  # .filled(float('nan'))
-        w_model_logit = metric[pop_s] * (
-            v0[pop_s] * rt + space_shifts[:, None, ...]
-        ) - torch.log(g[pop_s])
-        model_logit, weights = WeightedTensor.get_filled_value_and_weight(
-            w_model_logit, fill_value=0.0
-        )
-        return WeightedTensor(torch.sigmoid(model_logit), weights).weighted_value

--- a/src/leaspy/models/shared_speed_logistic.py
+++ b/src/leaspy/models/shared_speed_logistic.py
@@ -17,7 +17,7 @@ from leaspy.variables.specs import (
     VariableNameToValueMapping,
 )
 
-from .riemanian_manifold import LogisticInitializationMixin
+from .logistic import LogisticInitializationMixin
 from .time_reparametrized import TimeReparametrizedModel
 
 __all__ = ["SharedSpeedLogisticModel"]


### PR DESCRIPTION
This PR separates `logistic` and `linear` models from `riemanian_manifold` file for consistent structure.